### PR TITLE
Update cREAL Oracle address for westeurope cluster

### DIFF
--- a/CGPs/cgp-0046/mainnet.json
+++ b/CGPs/cgp-0046/mainnet.json
@@ -51,13 +51,13 @@
       {
         "contract": "SortedOracles",
         "function": "addOracle",
-        "args": ["TBD StableTokenBRL address", "0x6404d7e494bc7f700ffaeb96909a96c3f9214ed2"],
+        "args": ["TBD StableTokenBRL address", "0x554ba7f4d200c7b233b93b7f2223bc1ea7c467fd"],
         "value": "0"
       },
       {
         "contract": "GoldToken",
         "function": "transfer",
-        "args": ["0x6404d7e494bc7f700ffaeb96909a96c3f9214ed2", "1000000000000000000000"],
+        "args": ["0x554ba7f4d200c7b233b93b7f2223bc1ea7c467fd", "1000000000000000000000"],
         "value": "0"
       },
       {


### PR DESCRIPTION
While double checking the addresses we noticed that there was a key under the `mainnet-brl-oracle-weu3` vault named `mainnet-brl-oracle-weu2` so to avoid naming discrepancies we deleted the key and created a new one with the proper name (`mainnet-brl-oracle-weu3`), and hence the old address needs to be replaced.