### PR TITLE
CGP51: Bucket size update

### DIFF
--- a/CGPs/cgp-0051.md
+++ b/CGPs/cgp-0051.md
@@ -1,0 +1,56 @@
+---
+cgp: 44
+title: Increasing Mento Bucket Sizes for cUSD and cEUR
+date-created: 2021-10-28
+author: @martinvol, @rcroessmann, @sissnad, @tobikuhlmann
+status: DRAFT
+discussions-to: https://forum.celo.org/t/economic-parameters-bucket-sizes-and-reserve-allocation-cgp-40-cgp-43/1997
+governance-proposal-id: [if submitted]
+date-executed: [if executed] <date created on, in ISO 8601 (yyyy-mm-dd) format>
+---
+
+## Overview
+
+This Governance proposal aims to reduce the slippage incurred when trading Celo stable assets, that is cUSD and cEUR, via the Celo stability mechanism (often referred to as Mento). All else equal, a reduction of the Mento slippage, which can be achieved via an increase of the Mento `reserveFraction` parameter, can be expected to tighten the arbitrage bounds on the cUSD/USD and cEUR/EUR pairs (collectively referred to as cXXX/XXX in this proposal).
+
+Mento allows users to create or burn Celo stable assets by trading the cUSD/CELO and cEUR/CELO pairs with the reserve. It uses a constant-product-market-maker model to mitigate the depletion potential of the reserve by dynamically adjusting the on-chain price to one-sided trading. For more background on Mento, please refer to the [documentation](https://docs.celo.org/celo-codebase/protocol/stability).
+
+The `reserveFraction` parameter, which can be set for cEUR and cUSD individually, allows to control the sensitivity of the Mento prices to one-sided trading. The smaller this parameter, the smaller the resulting Mento bucket sizes and therefore the larger the price reaction to one-sided trading. 
+The main benefit of choosing a low `reserveFraction` is that this reduces the depletion potential of the reserve should there be imprecise CELO/USD oracle rates and/or manipulated CELO/USD market prices. This is because the Mento cXXX/CELO price adjusts quickly to one-sided trading if Mento buckets are small.
+The main downside of a low `reserveFraction` parameter is wider arbitrage bounds on cXXX/XXX prices. For more background on the effects of the `reserveFraction` parameter, please see the [Celo Stability Analysis](https://celo.org/papers/Celo_Stability_Analysis.pdf), especially sections 4.3.2 and 4.3.3.
+
+We propose to increase the `reserveFraction` parameters to adjust the above tradeoff to the current market environment, that is an increased volatility in the wider crypto market inducing the need for faster contractions and expansions for cUSD and cEUR.
+
+### Status
+  
+In governance proposal [CGP008](https://github.com/celo-org/governance/blob/main/CGPs/cgp-0008.md), the `reserveFraction parameter` for the cUSD/CELO Mento pair was increased from 0.1% to 0.5% and has remained at that level since then. The cEUR/CELO `reserveFraction` parameter was set to 0.13% via [CGP008](https://github.com/celo-org/governance/blob/d8e8dc1cd9882db4c6112b4a6c8e6e93e0e69311/CGPs/cgp-0022.md). Both of these values were set in an attempt to solve the tradeoff between a strong protection of the Celo reserve and tight arbitrage bounds on the stable asset prices in the best way possible at the time. 
+
+## Proposed Changes
+
+We propose to increase the `reserveFraction` parameter for cUSD from 0.5% to 2.0% and for cEUR from 0.13% to 0.5%. All else equal, this should roughly quadruple the daily expansion (contraction) amounts of cUSD  and cEUR that can be minted (contracted) at less than a 1% cost.
+
+1. Set cUSD `reserveFraction` to 2.0%
+  - Destination: Exchange (Proxy: 0x67316300f17f063085Ca8bCa4bd3f7a5a3C66275; Implementation: 0xEDF3F7e01037e4583de2659C5e243621Ea2501A4),`Exchange.setReserveFraction`
+  - Data: 20000000000000000000000 (2/100 * 10^24 = 1e22)
+  - Value: 0 (NA)
+
+2. Set cEUR `reserveFraction` to 0.5%
+  - Destination: ExchangeEUR (Proxy: 0xE383394B913d7302c49F794C7d3243c429d53D1d; Implementation: 0x622833AB6E9501C9072d2c706c60AaB5Ff0234d9),`Exchange.setReserveFraction`
+  - Data: 5000000000000000000000 (5/1000 * 10^24 = 5e21)
+  - Value: 0 (NA)
+
+## Verification
+
+1. Confirm proposal steps: run `celocli governance:view --proposalID $proposalID` 
+2. Confirm Exchange (cUSD) and ExchangeEUR (cEUR) addresses: run `celocli network:contracts`
+
+## Risks
+
+* Oracle rate risk: In case of imprecise CELO/USD oracle rates and/or manipulated CELO/USD market rates, users could exchange cUSD or CELO with the reserve at a price that does not reflect the current market valuation. The increased `reserveFraction` parameter would lead to a larger loss of the reserve in such a case. The equivalent argument holds for cEUR and the CELO/EUR rate.
+
+## Useful Links
+
+* [Mento Documentation](https://docs.celo.org/celo-codebase/protocol/stability/doto)
+* [The Celo Expansion & Contraction Mechanism](https://medium.com/celoorg/zooming-in-on-the-celo-expansion-contraction-mechanism-446ca7abe4f)
+* [Celo Stability Whitepaper](https://celo.org/papers/stability)
+* [Exchange Smart Contract Source Code](https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts/stability/Exchange.sol)

--- a/CGPs/cgp-0051.md
+++ b/CGPs/cgp-0051.md
@@ -21,6 +21,8 @@ The main downside of a low `reserveFraction` parameter is wider arbitrage bounds
 
 We propose to increase the `reserveFraction` parameters to adjust the above tradeoff to the current market environment, that is an increased volatility in the wider crypto market inducing the need for faster contractions and expansions for cUSD and cEUR.
 
+The here proposed parameter changes have been deployed, tested and validated on both Alfajores and Baklava. 
+
 ### Status
   
 In governance proposal [CGP008](https://github.com/celo-org/governance/blob/main/CGPs/cgp-0008.md), the `reserveFraction parameter` for the cUSD/CELO Mento pair was increased from 0.1% to 0.5% and has remained at that level since then. The cEUR/CELO `reserveFraction` parameter was set to 0.13% via [CGP008](https://github.com/celo-org/governance/blob/d8e8dc1cd9882db4c6112b4a6c8e6e93e0e69311/CGPs/cgp-0022.md). Both of these values were set in an attempt to solve the tradeoff between a strong protection of the Celo reserve and tight arbitrage bounds on the stable asset prices in the best way possible at the time. 

--- a/CGPs/cgp-0051.md
+++ b/CGPs/cgp-0051.md
@@ -1,7 +1,7 @@
 ---
-cgp: 44
+cgp: 51
 title: Increasing Mento Bucket Sizes for cUSD and cEUR
-date-created: 2021-10-28
+date-created: 2022-03-07
 author: @martinvol, @rcroessmann, @sissnad, @tobikuhlmann
 status: DRAFT
 discussions-to: https://forum.celo.org/t/economic-parameters-bucket-sizes-and-reserve-allocation-cgp-40-cgp-43/1997

--- a/CGPs/cgp-0051/cpg-0051.json
+++ b/CGPs/cgp-0051/cpg-0051.json
@@ -1,0 +1,14 @@
+[
+    {
+        "contract": "Exchange",
+        "function": "setReserveFraction",
+        "args": ["20000000000000000000000"], 
+        "value": "0"
+      },
+      {
+        "contract": "ExchangeEUR",
+        "function": "setReserveFraction",
+        "args": ["5000000000000000000000"],
+        "value": "0"
+      }
+]


### PR DESCRIPTION
Hey CGP Editors and Celo Community,

after[ CGP 44](https://github.com/celo-org/governance/blob/main/CGPs/cgp-0044.md) wasn't approved due to problems with the governance approver MultiSig last October, we would like to start a second attempt to update reserve fraction parameters for cUSD and cEUR, to adjust Mento trading conditions to the current market environment. The parameters slightly changed due to adjustments to the current market situation, which has a different volatility as well as expansion and contraction trading dynamic than last October, when the parameters were initially calibrated. 

This CGP has a short lead-time, we would like to propose it on-chain tomorrow, Tuesday 8. March 2022, evening. The reason for that is to combine efforts with the other two CGPs about to be resubmitted (reserve gift policy and contract release 6), and we hope that the approver MultiSig will be able to respond and approve this time.

The changes and json file of this PR, CGP 51, are deployed and successfully tested on both Baklava and Alfajores.

Thanks guys.

Tobi