### PR TITLE
[CGPXX]: Update blockGasLimit to 50M and targetDensity to 0.7

### DIFF
--- a/CGPs/cgp-0053.md
+++ b/CGPs/cgp-0053.md
@@ -73,7 +73,7 @@ In the previous graph is represented the block delta between the network block h
 
 Lastly, this image shows the per-second average of new blocks.
 
-In the view of the results showing stability in all the observed metrics, we can reach the conclusion that the network can handle an increment on the gas block limit to 50M without notoriously impacting the average block time.
+In the view of the results showing stability in all the observed metrics, we can reach the conclusion that the network can handle an increment on the gas block limit to 50M without negatively impacting the average block time.
 
 As a precaution measure, taking in count that the stress tests performed are not fully representative of all the possible usages of the network, we are also suggesting to change the gasPriceMinimum `target density` to `0.7`, to discourage long periods of stress on the network, making virtually impossible to fill more than 10 minutes of full blocks due to the high costs it would require.
 

--- a/CGPs/cgp-0053.md
+++ b/CGPs/cgp-0053.md
@@ -12,16 +12,16 @@ date-executed: <tbd>
 
 CGP - Celo Governance Proposal
 
-This proposal sets the block gas limit parameter of the Celo blockchain from `20M` to `50M` and the gasPriceMinimum's targetDensity to `0.8`. The change is motivated by the improvement on block processing thoughput with the latest celo-blockchain releases.
+This proposal sets the block gas limit parameter of the Celo blockchain from `20M` to `50M` and the gasPriceMinimum's targetDensity to `0.8`. The change is motivated by the improvement on block processing throughput with the latest celo-blockchain releases.
 
-The most relevant changes that possitivily impact the performance of the network are:
+The most relevant changes that positively impact the performance of the network are:
 
 - [Snapshots](https://blog.ethereum.org/2021/03/03/geth-v1-10-0/)
 - [CIP43: Block Context](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0043.md)
 
-For confirming the safety and stabilty of a block gas limit of `50M`, cLabs Blockchain Team have run loat and stability testing during the last weeks.
+For confirming the safety and stability of a block gas limit of `50M`, cLabs Blockchain Team have run load and stability testing during the last weeks.
 
-The change will increase the transaction thorughput by way of the increasing the block space by 150%, and also will increase the effective network target block for adjunsting the baseFee, that currently is `0.8 * blockSize` (`16M`) and will be `0.7 * blockSize` (`35M`).
+The change will increase the transaction throughput by way of the increasing the block space by 150%, and also will increase the effective network target block for adjusting the baseFee, that currently is `0.8 * blockSize` (`16M`) and will be `0.7 * blockSize` (`35M`).
 
 ## Proposed Changes
 
@@ -48,40 +48,42 @@ To check and validate the performance of the networks under high pressure of gas
 - Epoch: Each 500 blocks
 - Celo-blockchain version: 1.5.5
 - Celo-monorepo (protocol) version: f62781066e5534d591c65bbcea8592cfb90d3a56
-- Validator resources: CPU = 8 vCPUs (n2 GCP platoform); Memory = 32GiB
-- Proxy resources: CPU = 4 vCPUs (n2 GCP platoform); Memory = 16GiB
-- Block Gas Limit illustrated in this results: 50 million
-- The network was running on "preemptible" instances that can eventually be restarted by the cloud provider.
+- Validator resources: CPU = 8 vCPUs (n2 GCP platform); Memory = 32GiB
+- Proxy resources: CPU = 4 vCPUs (n2 GCP platform); Memory = 16GiB
+- Block Gas Limit illustrated in these results: 50 million
+- The network was running on "preemptible" instances that can eventually be restarted by the cloud provider (this causes some outsiders in the graphs caused by pod restarts)
 
-The load transactions were generated as token transfers, transfering different tokens and also using different currencies for paying the transaction fees. The network were running with a continued 50M load for 35 hours.
+The load transactions were generated as token transfers, transferring different tokens and also using different currencies for paying the transaction fees. The network were running with a continued 50M load for 24 hours in different intervals.
 
-As summury for the results we illustrate some of the metrics for a 110 validator network, with 50M block size, running on GCP n2-standard-8 (8vCPU and 32 GiB memory).
+![Block Gas Used](https://user-images.githubusercontent.com/5635989/167686033-5ac16aa4-254b-446e-a90c-c4dabdb77bc2.png)
 
-![Block Processing Time](https://user-images.githubusercontent.com/5635989/161053288-54e3a6f1-bc32-463d-8d56-382da46fbdf5.png)
+As summary for the results, we illustrate some metrics for a 110 validator network, with 50M block size, running on GCP n2-standard-8 (8vCPU and 32 GiB memory).
 
-The previous image represents how the block time (5 seconds) is splitted between the different steps of block construction and block consensous. Most of the block time is spent in `consensus_istanbul_backend_sleep`, that represents idle time.
+![Block Processing Time](https://user-images.githubusercontent.com/5635989/167684677-a8758d16-9998-4c11-98a7-9cf5dabdef37.png)
+
+The previous image represents how the block time (~5 seconds), split between the different steps of block construction and block consensus. The time spent in `consensus_istanbul_backend_sleep`, that represents idle time for the block time.
 
 For a 50M block size, a full node running on n2-standard-4 (4vCPU and 16 GiB memory) can keep synced without problems:
 
-![Full nodes block delta](https://user-images.githubusercontent.com/5635989/161053342-6be97d3d-8593-4b8b-adae-56d8d4b09a92.png)
+![Full nodes block delta](https://user-images.githubusercontent.com/5635989/167685485-46a9897d-9481-49f7-b139-b4d90808e9da.png)
 
-In the previous graph is represented the block delta between the network block head, and the latest block form each node. As show, none of the instances distanced more than two blocks from the head, and part of this can be caused by different timing with the metric probe.
+In the previous graph is represented the block delta between the network block head, and the latest block from each node. As show, none of the instances distanced more than one blocks from the head, and part of this can be caused by different timing with the metric probe (the spike shown in the graph was caused to a restart of the preemptible instance).
 
-![Block Rate limit](https://user-images.githubusercontent.com/5635989/161053448-5b8b6fc7-d64b-4b2d-b317-88b230201592.png)
+![Block Rate](https://user-images.githubusercontent.com/5635989/167686346-c77b7d17-19e9-4fa7-8567-acb30f7c0d2b.png)
 
-Lastly this image shows the per-second average of new blocks.
+Lastly, this image shows the per-second average of new blocks.
 
-In the view of the results showing stability in all the observed metrics, we can reach the conclusion that the network can handle an increament on the gas block limit to 50M without notoriously impacting the average block time.
+In the view of the results showing stability in all the observed metrics, we can reach the conclusion that the network can handle an increment on the gas block limit to 50M without notoriously impacting the average block time.
 
-As a precaution meassure, taking in count that the stress tests performed are not fully representative of all the possible usages of the network, we are also suggesting to change the gasPriceMinimum `target density` to `0.7`, to avoid long periods of stress of the network, making vitually impossible to fill more than 10 minutes of full blocks due to the high costs of it.
+As a precaution measure, taking in count that the stress tests performed are not fully representative of all the possible usages of the network, we are also suggesting to change the gasPriceMinimum `target density` to `0.7`, to discourage long periods of stress on the network, making virtually impossible to fill more than 10 minutes of full blocks due to the high costs it would require.
 
-This will allow us to maintain without any issue a constant flow of usage of 35M per block (without any price change), and absorb the high peaks of transactions without compromissing the network.
+The proposed change would allow the network to maintain a constant flow of usage of 35M per block (without any price change), and absorb the high peaks of transactions without compromising the network.
 
-As an example, if we stress the network and fill every block for 5 consecutive minutes, the gas price multiplier will be `~4.4k`, and as the gasPriceMinimumFloor right now is `1e8` it means that the cost of the gas will be `~4.4e11`. Which translates that a `100k` gas tx, will require to pay a fee of `4.4e16` => `0.044 celos`.
+As an example, if we stress the network and fill every block for 5 consecutive minutes, the gas price multiplier would be `~4.4k`, and as the `gasPriceMinimumFloor` right now is `1e8` wei it means that the `gasPriceMinimum` would increase to `~4.4e11` after those 5 minutes. Which translates that a `100k` gas tx, would require to pay a fee of `4.4e16` => `0.044 celos`.
 
-The same example but with 10 consecutive minutes of full block (`120 blocks`), it translate to a `~19200k` multiplier. That same tx will cost `192 celos`. This scenario is highly improbable except in a network attack, and it will be normalized again with a faster pase (59 consecutive blocks 20% full, for example)
+The same example but with 10 consecutive minutes of full block (`120 blocks`), it translates to a `~19200k` multiplier. That same tx will cost `192 celos`. This scenario is highly improbable except in a network attack, and it will be normalized again with a faster pace (59 consecutive blocks 20% full, for example)
 
-As another example a mixed load of 8 consecutive full blocks, followed by 2 consecutive blocks at 20% (10 blocks in total), a load of that patter for 10 minutes (120 blocks, 12 of those cycles) transaltes to a mutiplier in the bigger peak of `~1.2k`, and for a `100k` gas tx, a fee of `0.012 celos`
+As another example, a pattern load of 8 consecutive full blocks, followed by 2 consecutive blocks at 20% (10 blocks in total) maintained for 10 minutes (120 blocks, 12 of those cycles) translates to a multiplier in the bigger peak of `~1.2k`, which for a `100k` gas tx would require a tx fee of `0.012 celos`
 
 ## Verification
 
@@ -90,7 +92,7 @@ TODO
 ## Risks
 
 - While metrics in the testing environment indicated that consensus and block production remain within expected bounds, generally speaking, increases in block space mean higher computational needs which could impact consensus and block production under adversarial conditions that were not tested.
-- Increasing the block space could lead to a quicker growth of chain state which in the long run makes running full nodes more resource-intenstive and could affect decentralization adversely.
+- Increasing the block space could lead to a quicker growth of chain state, which in the long run makes running full nodes more resource-intensive and could affect decentralization adversely.
 
 ## Useful Links
 

--- a/CGPs/cgp-0053.md
+++ b/CGPs/cgp-0053.md
@@ -12,7 +12,7 @@ date-executed: <tbd>
 
 CGP - Celo Governance Proposal
 
-This proposal sets the block gas limit parameter of the Celo blockchain from `20M` to `50M` and the gasPriceMinimum's targetDensity to `0.8`. The change is motivated by the improvement on block processing throughput with the latest celo-blockchain releases.
+This proposal sets the block gas limit parameter of the Celo blockchain from `20M` to `50M` and the gasPriceMinimum's targetDensity from `0.8` to `0.7`. The change is motivated by the improvement on block processing throughput with the latest celo-blockchain releases.
 
 The most relevant changes that positively impact the performance of the network are:
 
@@ -28,7 +28,7 @@ The change will increase the transaction throughput by way of the increasing the
 1. Increase the block gas limit parameter:
 
     - Destination: Call `setBlockGasLimit` on the `BlockchainParameters` smart contract owned by `Governance`
-    - Data: 35 000 0000 (35 Million)
+    - Data: 50 000 000 (50 Million)
     - Value: 0 (NA)
 
 2. Decrease the gasPriceMinimum's target density:

--- a/CGPs/cgp-0053.md
+++ b/CGPs/cgp-0053.md
@@ -1,0 +1,82 @@
+---
+cgp: <to be assigned>
+title: Increase the gasLimit to 35M
+date-created: 2022-04-03
+author: Mariano Cortesi (@mcortesi5), Javier Cortejoso (@jcortejoso)
+status: DRAFT
+discussions-to: <tbd>
+governance-proposal-id: <tbd>
+date-executed: <tbd>
+---
+## Overview
+
+CGP - Celo Governance Proposal
+
+This proposal sets the block gas limit parameter of the Celo blockchain to 35M from 20M. The change is motivated by the improvement on block processing thoughput with the latest celo-blockchain releases.
+
+The most relevant changes that possitivily impact the performance of the network are:
+
+- [Snapshots](https://blog.ethereum.org/2021/03/03/geth-v1-10-0/)
+- [CIP43: Block Context](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0043.md)
+
+For confirming the safety and stabilty of a block gas limit of 35M, cLabs Blockchain Team have run loat and stability testing during the last weeks.
+
+The change will increase the transaction thorughput by way of the increasing the block space by 75%, and also will increase the effective network target block for adjunsting the baseFee, that currently is 0.8 * blockSize.
+
+## Proposed Changes
+
+1. Increase the block gas limit parameter:
+
+- Destination: Call `setBlockGasLimit` on the `BlockchainParameters` smart contract owned by `Governance`
+- Data: 35 000 0000 (35 Million)
+- Value: 0 (NA)
+
+## Testing
+
+To check and validate the performance of the networks under high pressure of gas consumption, a Celo testnet was deployed with the following parameters:
+
+- Running validators: 110
+- Elected validators: 110
+- Proxied validators: 10
+- Block time: 5 seconds
+- Epoch: Each 17280 blocks
+- Celo-blockchain version: 1.5.5
+- Celo-monorepo (protocol) version: f62781066e5534d591c65bbcea8592cfb90d3a56
+- Validator resources: CPU = 8 vCPUs (n2 GCP platoform); Memory = 32GiB
+- Proxy resources: CPU = 4 vCPUs (n2 GCP platoform); Memory = 16GiB
+- Block Gas Limit illustrated in this results: 40 million (vs 35M as proposed)
+- The network was running on "preemptible" instances that can eventually be restarted by the cloud provider.
+
+The load transactions were generated as token transfers, transfering different tokens and also using different currencies for paying the transaction fees. The network were running with a continued 40M load for 35 hours.
+
+As summury for the results we illustrate some of the metrics for a 110 validator network, with 40M block size, running on GCP n2-standard-8 (8vCPU and 32 GiB memory).
+
+![Block Processing Time](https://user-images.githubusercontent.com/5635989/161053288-54e3a6f1-bc32-463d-8d56-382da46fbdf5.png)
+
+The previous image represents how the block time (5 seconds) is splitted between the different steps of block construction and block consensous. Most of the block time is spent in `consensus_istanbul_backend_sleep`, that represents idle time.
+
+For a 40M block size, a full node running on n2-standard-4 (4vCPU and 16 GiB memory) can keep synced without problems:
+
+![Full nodes block delta](https://user-images.githubusercontent.com/5635989/161053342-6be97d3d-8593-4b8b-adae-56d8d4b09a92.png)
+
+In the previous graph is represented the block delta between the network block head, and the latest block form each node. As show, none of the instances distanced more than two blocks from the head, and part of this can be caused by different timing with the metric probe.
+
+![Block Rate limit](https://user-images.githubusercontent.com/5635989/161053448-5b8b6fc7-d64b-4b2d-b317-88b230201592.png)
+
+Lastly this image shows the per-second average of new blocks.
+
+In the view of the results showing stability in all the observed metrics, we can reach the conclusion that the network can handle an increament on the gas block limit to 35M without notoriously impacting the average block time.
+
+## Verification
+
+TODO
+
+## Risks
+
+- While metrics in the testing environment indicated that consensus and block production remain within expected bounds, generally speaking, increases in block space mean higher computational needs which could impact consensus and block production under adversarial conditions that were not tested.
+- Increasing the block space could lead to a quicker growth of chain state which in the long run makes running full nodes more resource-intenstive and could affect decentralization adversely.
+
+## Useful Links
+
+* [CGP12] (https://raw.githubusercontent.com/celo-org/governance/main/CGPs/cgp-0011.md)
+

--- a/CGPs/cgp-0053.md
+++ b/CGPs/cgp-0053.md
@@ -75,7 +75,7 @@ Lastly, this image shows the per-second average of new blocks.
 
 In the view of the results showing stability in all the observed metrics, we can reach the conclusion that the network can handle an increment on the gas block limit to 50M without negatively impacting the average block time.
 
-As a precaution measure, taking in count that the stress tests performed are not fully representative of all the possible usages of the network, we are also suggesting to change the gasPriceMinimum `target density` to `0.7`, to discourage long periods of stress on the network, making virtually impossible to fill more than 10 minutes of full blocks due to the high costs it would require.
+As a precautionary measure, taking into account that the stress tests performed are not fully representative of all the possible usages of the network, we are also suggesting to change the gasPriceMinimum `target density` to `0.7`, to discourage long periods of stress on the network, making virtually impossible to fill more than 10 minutes of full blocks due to the high costs it would require.
 
 The proposed change would allow the network to maintain a constant flow of usage of 35M per block (without any price change), and absorb the high peaks of transactions without compromising the network.
 

--- a/CGPs/cgp-0053.md
+++ b/CGPs/cgp-0053.md
@@ -1,8 +1,8 @@
 ---
 cgp: <to be assigned>
-title: Increase the gasLimit to 35M
+title: Increase the gasLimit to 50M and gas targetDensity to 0.7
 date-created: 2022-04-03
-author: Mariano Cortesi (@mcortesi5), Javier Cortejoso (@jcortejoso)
+author: Mariano Cortesi (@mcortesi5), Javier Cortejoso (@jcortejoso), Gastón Ponti (@gastonponti)
 status: DRAFT
 discussions-to: <tbd>
 governance-proposal-id: <tbd>
@@ -12,24 +12,30 @@ date-executed: <tbd>
 
 CGP - Celo Governance Proposal
 
-This proposal sets the block gas limit parameter of the Celo blockchain to 35M from 20M. The change is motivated by the improvement on block processing thoughput with the latest celo-blockchain releases.
+This proposal sets the block gas limit parameter of the Celo blockchain from `20M` to `50M` and the gasPriceMinimum's targetDensity to `0.8`. The change is motivated by the improvement on block processing thoughput with the latest celo-blockchain releases.
 
 The most relevant changes that possitivily impact the performance of the network are:
 
 - [Snapshots](https://blog.ethereum.org/2021/03/03/geth-v1-10-0/)
 - [CIP43: Block Context](https://github.com/celo-org/celo-proposals/blob/master/CIPs/cip-0043.md)
 
-For confirming the safety and stabilty of a block gas limit of 35M, cLabs Blockchain Team have run loat and stability testing during the last weeks.
+For confirming the safety and stabilty of a block gas limit of `50M`, cLabs Blockchain Team have run loat and stability testing during the last weeks.
 
-The change will increase the transaction thorughput by way of the increasing the block space by 75%, and also will increase the effective network target block for adjunsting the baseFee, that currently is 0.8 * blockSize.
+The change will increase the transaction thorughput by way of the increasing the block space by 150%, and also will increase the effective network target block for adjunsting the baseFee, that currently is `0.8 * blockSize` (`16M`) and will be `0.7 * blockSize` (`35M`).
 
 ## Proposed Changes
 
 1. Increase the block gas limit parameter:
 
-- Destination: Call `setBlockGasLimit` on the `BlockchainParameters` smart contract owned by `Governance`
-- Data: 35 000 0000 (35 Million)
-- Value: 0 (NA)
+    - Destination: Call `setBlockGasLimit` on the `BlockchainParameters` smart contract owned by `Governance`
+    - Data: 35 000 0000 (35 Million)
+    - Value: 0 (NA)
+
+2. Decrease the gasPriceMinimum's target density:
+
+    - Destination: Call `setTargetDensity` on the `GasPriceMinimum` smart contract owned by `Governance`
+    - Data: 700 000 000 000 000 000 000 000 (7e23 => 0.7)
+    - Value: 0 (NA)
 
 ## Testing
 
@@ -39,23 +45,23 @@ To check and validate the performance of the networks under high pressure of gas
 - Elected validators: 110
 - Proxied validators: 10
 - Block time: 5 seconds
-- Epoch: Each 17280 blocks
+- Epoch: Each 500 blocks
 - Celo-blockchain version: 1.5.5
 - Celo-monorepo (protocol) version: f62781066e5534d591c65bbcea8592cfb90d3a56
 - Validator resources: CPU = 8 vCPUs (n2 GCP platoform); Memory = 32GiB
 - Proxy resources: CPU = 4 vCPUs (n2 GCP platoform); Memory = 16GiB
-- Block Gas Limit illustrated in this results: 40 million (vs 35M as proposed)
+- Block Gas Limit illustrated in this results: 50 million
 - The network was running on "preemptible" instances that can eventually be restarted by the cloud provider.
 
-The load transactions were generated as token transfers, transfering different tokens and also using different currencies for paying the transaction fees. The network were running with a continued 40M load for 35 hours.
+The load transactions were generated as token transfers, transfering different tokens and also using different currencies for paying the transaction fees. The network were running with a continued 50M load for 35 hours.
 
-As summury for the results we illustrate some of the metrics for a 110 validator network, with 40M block size, running on GCP n2-standard-8 (8vCPU and 32 GiB memory).
+As summury for the results we illustrate some of the metrics for a 110 validator network, with 50M block size, running on GCP n2-standard-8 (8vCPU and 32 GiB memory).
 
 ![Block Processing Time](https://user-images.githubusercontent.com/5635989/161053288-54e3a6f1-bc32-463d-8d56-382da46fbdf5.png)
 
 The previous image represents how the block time (5 seconds) is splitted between the different steps of block construction and block consensous. Most of the block time is spent in `consensus_istanbul_backend_sleep`, that represents idle time.
 
-For a 40M block size, a full node running on n2-standard-4 (4vCPU and 16 GiB memory) can keep synced without problems:
+For a 50M block size, a full node running on n2-standard-4 (4vCPU and 16 GiB memory) can keep synced without problems:
 
 ![Full nodes block delta](https://user-images.githubusercontent.com/5635989/161053342-6be97d3d-8593-4b8b-adae-56d8d4b09a92.png)
 
@@ -65,7 +71,17 @@ In the previous graph is represented the block delta between the network block h
 
 Lastly this image shows the per-second average of new blocks.
 
-In the view of the results showing stability in all the observed metrics, we can reach the conclusion that the network can handle an increament on the gas block limit to 35M without notoriously impacting the average block time.
+In the view of the results showing stability in all the observed metrics, we can reach the conclusion that the network can handle an increament on the gas block limit to 50M without notoriously impacting the average block time.
+
+As a precaution meassure, taking in count that the stress tests performed are not fully representative of all the possible usages of the network, we are also suggesting to change the gasPriceMinimum `target density` to `0.7`, to avoid long periods of stress of the network, making vitually impossible to fill more than 10 minutes of full blocks due to the high costs of it.
+
+This will allow us to maintain without any issue a constant flow of usage of 35M per block (without any price change), and absorb the high peaks of transactions without compromissing the network.
+
+As an example, if we stress the network and fill every block for 5 consecutive minutes, the gas price multiplier will be `~4.4k`, and as the gasPriceMinimumFloor right now is `1e8` it means that the cost of the gas will be `~4.4e11`. Which translates that a `100k` gas tx, will require to pay a fee of `4.4e16` => `0.044 celos`.
+
+The same example but with 10 consecutive minutes of full block (`120 blocks`), it translate to a `~19200k` multiplier. That same tx will cost `192 celos`. This scenario is highly improbable except in a network attack, and it will be normalized again with a faster pase (59 consecutive blocks 20% full, for example)
+
+As another example a mixed load of 8 consecutive full blocks, followed by 2 consecutive blocks at 20% (10 blocks in total), a load of that patter for 10 minutes (120 blocks, 12 of those cycles) transaltes to a mutiplier in the bigger peak of `~1.2k`, and for a `100k` gas tx, a fee of `0.012 celos`
 
 ## Verification
 

--- a/CGPs/cgp-0053.md
+++ b/CGPs/cgp-0053.md
@@ -65,11 +65,11 @@ The previous image represents how the block time (~5 seconds), split between the
 
 For a 50M block size, a full node running on n2-standard-4 (4vCPU and 16 GiB memory) can keep synced without problems:
 
-![Full nodes block delta](https://user-images.githubusercontent.com/5635989/167685485-46a9897d-9481-49f7-b139-b4d90808e9da.png)
+![Full nodes block delta](https://user-images.githubusercontent.com/5635989/167696090-25f266ab-a4b1-48e9-82a5-dc7f95ffb4cf.png)
 
 In the previous graph is represented the block delta between the network block head, and the latest block from each node. As show, none of the instances distanced more than one blocks from the head, and part of this can be caused by different timing with the metric probe (the spike shown in the graph was caused to a restart of the preemptible instance).
 
-![Block Rate](https://user-images.githubusercontent.com/5635989/167686346-c77b7d17-19e9-4fa7-8567-acb30f7c0d2b.png)
+![Block Rate](https://user-images.githubusercontent.com/5635989/167696586-e0a0c964-8bff-49cc-a762-6cc9b8ae705f.png)
 
 Lastly, this image shows the per-second average of new blocks.
 

--- a/CGPs/cgp-0053/cgp-0053.json
+++ b/CGPs/cgp-0053/cgp-0053.json
@@ -1,0 +1,8 @@
+[
+    {
+        "contract": "BlockchainParameters",
+        "function": "setBlockGasLimit",
+        "args": ["35000000"], 
+        "value": "0"
+      }
+]

--- a/CGPs/cgp-0053/cgp-0053.json
+++ b/CGPs/cgp-0053/cgp-0053.json
@@ -1,8 +1,14 @@
 [
-    {
-        "contract": "BlockchainParameters",
-        "function": "setBlockGasLimit",
-        "args": ["35000000"], 
-        "value": "0"
-      }
+  {
+    "contract": "BlockchainParameters",
+    "function": "setBlockGasLimit",
+    "args": ["50000000"],
+    "value": "0"
+  },
+  {
+    "contract": "GasPriceMinimum",
+    "function": "setTargetDensity",
+    "args": ["700000000000000000000000"],
+    "value": "0"
+  }
 ]


### PR DESCRIPTION
Hi Celo Community and Developers,

As a follow-up of [this PR](https://github.com/celo-org/governance/pull/129), based on some of the feedback received and additional tests executed, we'd like to propose increase block size limit to 50 gas million and reduce target density from 0.8 to 0.7. Any kind of feedback is kindly welcomed.

[Forum discussion](https://forum.celo.org/t/propose-to-increase-block-gas-limit-to-50m-gas-and-target-density-to-0-7/3519).

Thank you.