### PR TITLE
CGP 0054: Reopening the CCF

### DIFF
--- a/CGPs/cgp-0054.md
+++ b/CGPs/cgp-0054.md
@@ -1,3 +1,13 @@
+---
+cgp: 17
+title: Reopening of the Celo Community Fund
+date-created: 
+author: @MayaRB#2593 @Wade | TPT#4475 @Thylacine | VladiatorLabs.io#6470
+status: PROPOSAL
+date-executed: 
+governance-proposal-id: 
+---
+
 # CGP: Reopening of the Celo Community Fund
 
 ## 1. Goal

--- a/CGPs/cgp-0054.md
+++ b/CGPs/cgp-0054.md
@@ -1,0 +1,173 @@
+# CGP: Reopening of the Celo Community Fund
+
+## 1. Goal
+The Celo Community Fund (CCF) is not currently open for applications as the original stewardship has drawn to a close. This proposal is for a continuation of management of the CCF under new stewards and broadly similar goals (with some focus tweaks from the past year’s experience and community feedback). 
+
+**Mission**: The Celo Community Fund’s mission is to support those who are building a financial system that creates conditions of prosperity for everyone.
+
+We propose to continue to fund a diverse set of projects to help in achieving Celo’s mission. There might be some overlap with Celo Foundation’s funding process but the Celo Community Fund (CCF) will help:
+- An essential avenue for ecosystem grants that is independent and not tied to the Celo Foundation.
+- Allows prospective projects the avenue to build upon Celo without having to acquire VC funding
+- Gives smaller projects and entrepreneurs the ability to empower themselves and start their passion project.
+- Fosters a healthy ecosystem
+- Supports decentralisation and provides greater transparency 
+- Provide a quick turnaround on applications 
+
+## 2. Progressive Decentralization
+
+As per feedback from CCF1 we will continue to use a simple proposal that can be voted on by the community so that we can get it passed. The primary goal is to help enable quality projects that need funding.
+We aim to continue the process of electing the stewards giving them the ability to make decisions on a pre-approved amount of CELO. This will help alleviate the current tension of not having enough voter turnouts for Celo Governance Proposals. The current Celo Governance Process has high threshold requirements and a lot of coordination is required to get proposals to pass. In addition, it doesn't meet the needs of the CCF where additional time is required by the stewards to vet projects before bringing them to vote.
+Like CCF1 we do give the power to the stewards, trust has to be earned over time. So this proposal will set forth some controls in place to avoid misbehaviour/bias by the stewards. 
+
+## 3.  Implementation
+
+We aim to continue the existing CCF1 process in order to re-activate the CCF without having to build a complicated governance process that may or may not work. Instead, the plan is to start working with a simple process, learn as we grow, and then use the lessons to create a robust decentralized process later on. We will try to save some costs by using cheaper alternatives support functions (forms etc).
+The following is the process we are recommending:
+- 2-of-3 smart contract: that is controlled by the elected stewards.
+- Governance smart contract owned: The Governance smart contract would approve the funds requested by the stewards. If required, CELO owners have the ability to withdraw the approval of funds that have not yet been moved.
+- Implementation: We plan to get support from cLabs to deploy a multisig contract and perform the ERC20 approval for the funds we are requesting to the deployed multisig.
+- Entity: We will request help from the legal and regulatory team at Celo Foundation to help set up a new appropriate entity.
+
+## 4. Stewards, experts and applicants
+
+The role of the stewards will be to:
+- Conduct community outreach to get projects built on Celo.
+- Assess applicants and their projects based on their mission, technical ability, merit, and integrity.
+- Support applicants throughout the application process.
+- Collaborate to decide if a project's grant is successful.
+- Support applicants throughout the grant cycle as required, and as able. 
+- Build a document to help the current and future operations of the Celo Community fund. We will use the document - CCF v1 - to guide us as we transition. 
+- Commit to increased transparency and dialogue with the community.
+
+The role of subject matter experts is:
+- Conduct community outreach to get projects built on Celo
+- Steer potential grantees towards the community fund
+- Provide assistance regarding projects that fall under their geographic or special knowledge area
+- To advise the stewards, as appropriate. However, they do not hold decision making powers.
+
+Subject matter experts will be determined by the stewards and may change throughout this 12-month tenure.
+
+Grant applicants will complete an application form similar to that used by CCF1 and the stewards will vet the projects to the best of their abilities either by themselves or, if needed, getting feedback from appropriate subject matter experts.
+
+The stewards will publish information about approved applications such as - team, proposed use of funds, and amount funded. Declined applications can expect to receive private feedback and details will not be published.
+
+If an applicant feels that they were unfairly denied funding from the CCF’s budget, then the conflict resolution process would be for them to submit a spend proposal via CGP for all CELO owners to vote on.
+
+## 5. CCF focus areas
+
+In response to the feedback from the community, we have decided to narrow down our focus to a few areas that we believe will have the greatest impact on Celo achieving product-market fit. Those areas are listed below but are not exhaustive: 
+
+**Community tools**
+Examples include: Desktop/browser/hardware wallets, developer tools, governance voting applications, block explorers, validator metrics dashboards, etc.
+
+**Research**
+Examples include: Support people and projects that want to conduct research. This can include both technical and non-technical areas relevant to Celo.
+
+**Education**
+Examples include: Create educational content, and host Celo-related talks. We are also open to considering other great teams/projects that might be beneficial to Celo’s mission/ecosystem.
+
+**Other**
+Anything else aligned with Celo’s mission. 
+
+## 6. Funding Projects
+
+We hope to fund projects that we believe will be able to deliver measurable key results in exchange for an average of 20k-45k CELO. Grants are nominated in USD, but paid in CELO using a 90 day  time weighted average price (TWAP). 
+
+*We may need provision during the term to swap CELO for cUSD if needed  to honour our liabilities in case of volatile fluctuations. 
+
+## 7. Communication
+
+Within 48 hours of funding a proposal, we will disclose the amount, team, and use of funds. We will maintain a public spreadsheet with the following information for community fund recipients: project name, website/github, recipient name(s), funding date, funding amount, use of funds. 
+
+
+## 8. Budget Request
+
+- Amount: 800,000 CELO (Approximately 8% of the fund)
+- Compensation of ~$134 /hr/steward assuming:
+    * An estimated 10/hours a week work for a steward (although may vary)
+    * 12 months of work is required
+    * Compensation is paid in CELO, at the USD rate above using a 90 day TWAP
+    * 4x (max) subject matter experts work an estimated 4hrs/week
+    * Less than $450/month in operational expenses
+
+In this execution, the governance proposal is approving 800,000 CELO allowance of the community fund (the governance address) to the multisig address rather than transferring the CELO fund to the multi-sig contract itself. This method allows flexibility in removing the allowance later if needed and de-risks lost funds if ever the multisig becomes inaccessible.
+
+## 9. Multisig owners
+
+**Verification**
+All the transactions that the stewards will make will be visible on-chain using our multisig address - 0xda2069f47D252121c2288301D6EF50B87220A693 and one can compare that with our public announcements.
+
+## 10. Risks
+
+- Loss of funds: While we do give the power to the stewards, trust has to be earned over time as it was with CCF1. We hope to build on this trust, but there is still a small risk. However, it is mitigated as all the three stewards are part of the Celo ecosystem without any prior relationship between them. 
+- Bias by the stewards: If a proposer feels that they were unfairly denied funding from the steward’s budget, then the conflict resolution process would be for them to submit a spend proposal via CGP for all CELO owners to vote on.
+
+## 11. Responsible Disclosure
+
+As part of the operational set up, we will disclose the following policies for full transparency.
+- Gift Policy
+- Conflicts Of Interest
+
+
+## 12. Name Change 
+
+Due to the Celo Community Fund (CCF) name being used for this grants fund as well as for other Community Funds governed by CELO holders, we are proposing to change the name of the grants fund to distinguish it and make it easier for the community. We are suggesting the following new name for the CCF: **Prezenti**, to be voted on in this CGP. 
+
+**Prezenti** in Esperanto means to give, present, bring into the presence of. (Less frequent translations are: gift, offer, tender, feature, render).
+
+## 13. CGP Vote
+
+### 13.1 Smart Contract
+
+- 2-of-3 multi-signature smart contract that is controlled by the elected stewards. Our proposal is to have three stewards within our group.
+- The 2-of-3 CCF smart contract will be owned by the Governance smart contract so that CELO owners can claw back CELO via CGP, if required.
+
+### 13.2 Term
+
+- The following members would like to nominate themselves for the role of the stewards:
+    * Aaron Boyd
+    * Wade Abel
+    * Maya Richardson-Brown
+- The term we propose is until funds are spent with a goal of dispersing our budget to qualified projects within 12 months after the elections and the appropriate steward entity is created.
+
+### 13.3 Voting on the CCF2 proposal and the stewards
+
+We are asking the community to vote on the following (in one vote): 
+    1. On the revised proposal above
+    2. and for the stewards to manage this proposal
+
+This is due the to following reasons:
+- Prevent voter fatigue: by making them vote on two things. It’ll be easy to rally the Celo community behind one CGP.
+- Keep the Celo Community Fund flexible: We (Wade, Aaron and Maya) are applying as stewards and are requesting a certain amount to disperse. Another steward team could also make a similar proposal to use a part of the fund if needed.
+
+
+## Appendix:
+
+### Proposers:
+
+#### Aaron Boyd
+**Background:** Software engineer for nearly 20 years, worked the better part of 15 years in the financial services industry in Australia (banking, insurance, superannuation). Active in the blockchain space since 2013 and advocate for economic self-determination.
+
+**Current work:**  Founder and operator of VladiatorLabs.io, a protocol-aligned infrastructure company currently in the process of incorporating in Switzerland and expanding to other proof-of-stake networks, especially in the Cosmos ecosystem. Vladiator Labs is a founding project in the Staking Defense League, an infrastructure special interests group aimed at promoting decentralization in the staking space.
+Additionally has worked briefly as a contractor within cLabs on some minor projects. Involved in the Celo ecosystem since the incentivised testnet and have been supported by the Celo Foundation as an elected validator since genesis (over two different validator groups). 
+Freelance Solidity, blockchain, database and cloud engineer and recently has worked with RaveSpace on metaverse NFT gallery https://musee-dezentral.com.
+
+**Possible disclosures:** Vladiator Labs is a current CCF1 grant recipient for our block map and attestation tool https://vido.vladiatorlabs.io, a Foundation vote recipient, and a Foundation grant recipient for operating an ODIS signer as part of the phone number privacy module. 
+
+
+#### Maya Richardson-Brown 
+**Background:** I am passionate about making a positive impact in the world we live in. As a project manager, I spent 5 years running a low carbon technology grant programme, disbursing over £50m GBP.  For 7 years I worked for Save the Children supporting end-to-end grant management in East Africa, identifying, securing, applying and managing funds from a huge variety of donors. Because of these roles I have the unique experience and knowledge of being both the donor and recipient. 
+Since Feb 2021 I have been Chief Operating Officer for TrustWorks Ltd, a UK based fintech building on Celo, helping them deliver cash transfer programs in Latin America to help refugees/vulnerable users use Celo to meet their basic household needs. I have the skills to enable a slick, simple and transparent granting system and process, whilst helping to expand the fund’s impact and further Celo's reach.
+
+**Current work:** My role as COO with Trustworks Ltd is coming to an end in July 2022. I am now a part-time founding contributor for Kakuza.
+
+**Possible disclosures:** TrustWorks Ltd was a CCF1 grant recipient, with the grant finishing in June 2022.   
+
+#### Wade Abel 
+**Background:** Operates The Passive Trust, an infrastructure provider for blockchain networks. The Passive Trust runs a validator group that has been running on Celo since Genesis. The Passive Trust has distributed a lot of the funds received from operating the Group and Validator to fund and support projects built on Celo. This includes Moola, Ubeswap, ImpactMarket, Poof Cash and Resource Network. Wade was initially part of the Mentor/mentee program in The Great Celo Bake Off, his motivation for becoming a steward is to help potential entrepreneurs and engineers to be able to get funding through grants and be given an opportunity like he was.
+
+
+**Current Work:** Operates The Passive Trust. I also contribute to multiple DAOs and open source projects.
+
+
+**Possible disclosures:** N/A

--- a/CGPs/cgp-0054/cgp-0054.json
+++ b/CGPs/cgp-0054/cgp-0054.json
@@ -1,0 +1,8 @@
+[
+    {
+    "contract": "GoldToken",
+    "function": "approve",
+    "args": ["0xda2069f47D252121c2288301D6EF50B87220A693","800000000000000000000000"],
+    "value": "0"
+    }
+]


### PR DESCRIPTION
This proposal is regarding the reopening of the CCF that was created in CGP 17. The fund has been closed to new applicants while the initial stewards wind down their term and close it after current grants are completed. This proposal at a high level is for:

- Using the initial fund as a template
- Change of stewards
- Request for additional funding via spend approval of the Celo Community Fund 

The initial discussion regarding this proposal took place on the [Celo forum](https://forum.celo.org/t/reopening-of-the-celo-community-fund/3475)