### PR TITLE
CGP 58: Correct Number in Scientific Notation

### DIFF
--- a/CGPs/cgp-0058.md
+++ b/CGPs/cgp-0058.md
@@ -37,7 +37,7 @@ We propose to increase the `reserveFraction` parameter for cREAL from 0.025% to 
 
 1. Set cREAL `reserveFraction` to ~~0.15%~~ 0.5%
   - Destination: ExchangeBRL (Proxy: 0x8f2cf9855C919AFAC8Bd2E7acEc0205ed568a4EA; Implementation: 0x21772Fc92AB1B15dfE4ed7559EaD98eDba883feE),`Exchange.setReserveFraction`
-  - Data: ~~1500000000000000000000 (0.15/100 * 10^24 = 1e22)~~ 5000000000000000000000 (0.5/100 * 10^24 = 1e22)
+  - Data: ~~1500000000000000000000 (0.15/100 * 10^24 = 1.5e21)~~ 5000000000000000000000 (0.5/100 * 10^24 = 5e21)
   - Value: 0 (NA)
 
 


### PR DESCRIPTION
This PR corrects a mistake of the parameter represented in scientific notation