### PR TITLE
Add Former CGP Editors To New Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 This is the Celo Governance repository used for coordination by the community members.
 
 The CGP Editors are:
-* Elizabeth Barnes (@ebethbarnes)
 * Will Kraft (@willkraft)
 * Eric Nakagawa (@ericnakagawa)
 * Chris Wilson (@calicokittencat)
 
 Emeritus CGP Editors are:
 * Ronan McGovern (@Pinotio)
+* Elizabeth Barnes (@ebethbarnes)
 * Yaz Khoury (@YazzyYaz)
 
 We regularly hold governance calls to discuss proposals. See below for a summary of past calls.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ The CGP Editors are:
 * Eric Nakagawa (@ericnakagawa)
 * Chris Wilson (@calicokittencat)
 
+Emeritus CGP Editors are:
+* Ronan McGovern (@Pinotio)
+* Yaz Khoury (@YazzyYaz)
+
 We regularly hold governance calls to discuss proposals. See below for a summary of past calls.
 
 |  №  |      Date       | Agenda | Notes | Recording |


### PR DESCRIPTION
To preserve history of the Celo governance process, removing the names of former CGP Editors is extreme and not the best practice for when it comes to looking at historical contexts of an open-source process.

Instead, moving them to another section is a better solution.

This is done in Ethereum and other places https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1.md#eip-editors