### PR TITLE
CGP 98: Add EUROC/XOF Oracles

### DIFF
--- a/CGPs/cgp-0098.md
+++ b/CGPs/cgp-0098.md
@@ -1,0 +1,121 @@
+---
+cgp: 98
+title: Add EUROC/XOF oracles
+date-created: 2023-09-12
+author: "@nvtaveras"
+status: DRAFT
+discussions-to: https://forum.celo.org/t/dunia-launching-exof-on-celo/6261
+governance-proposal-id: TBD
+date-executed: TBD
+---
+
+## Overview
+
+In this governance proposal, we propose the addition of an `EUROC/XOF` oracle rate. This rate will be used for creating an `eXOF/axlEUROC` pool as part of our upcoming collaboration with Dunia. These oracles were unfortunately not included in the recent [CGP 94](https://github.com/celo-org/governance/blob/main/CGPs/cgp-0094.md) proposal, but are important to have an accurate exchange rate in the underlying pool, and therefore protecting the reserve. For more background on the upcoming eXOF launch, please take a look at [Dunia launching eXOF on Celo](https://forum.celo.org/t/dunia-launching-exof-on-celo/6261).
+
+Similar to [CGP 94](https://github.com/celo-org/governance/blob/main/CGPs/cgp-0094.md), The set of oracle providers proposed for `EUROC/XOF` will be provided only by Mento Labs in the early test stage with the goal of broadening the set of oracle providers in a future upgrade.
+
+### Status
+
+Following a similar approach as seen in previous proposals like [CGP 86](https://github.com/celo-org/governance/blob/main/CGPs/cgp-0086.md) and [CGP 94](https://github.com/celo-org/governance/blob/main/CGPs/cgp-0094.md) we recommend associating the `EUROC/XOF` rate identifier with the subsequent address derived from the ticker pair:
+
+```solidity
+address(uint160(uint256(keccak256("EUROCXOF"))))
+// == 0xed35e46b095197da30ddffa5b91d386886d5ce0d
+```
+
+This CGP proposes to enable the following addresses to report the EUROC/XOF rate:
+
+#### Mento Labs
+
+1. `0xdda1d71f3d5a6090bc04b77a18925fab7054d9c3`
+2. `0xee1d05f81e90b8ece440de6141282404e83830ce`
+3. `0xff6e35c6119742fd1eb3db780d976c4e55585108`
+4. `0x59eac333453279e71a3a98b4b72bdfa99ca51ad3`
+5. `0x378b95092bed2acb0d3ae6ab9c045eef1c250872`
+6. `0xc5a86597d514b423579684cdf9f49b6df37e3689`
+7. `0x8e1423ca0bcb15093f52d1d07675e0aa04e3da75`
+8. `0xa47e6a8a7db5ee22b5293704a4f0f5f8fdaab06f`
+9. `0x77d148efdd40202d0eec787073a70c7f6bc9c485`
+10. `0xfef8748fd3f039fb8cfa77c7744b171f4396659c`
+
+## Proposed Changes
+
+-- `EUROC/XOF` oracle rate transactions --
+
+1. Whitelist oracles
+
+- Destination: SortedOracles.addOracle
+- Data: `0xed35e46b095197da30ddffa5b91d386886d5ce0d`, `0xdda1d71f3d5a6090bc04b77a18925fab7054d9c3`)
+- Value: 0
+
+2. Whitelist oracles
+
+- Destination: SortedOracles.addOracle
+- Data: `0xed35e46b095197da30ddffa5b91d386886d5ce0d`, `0xee1d05f81e90b8ece440de6141282404e83830ce`)
+- Value: 0
+
+3. Whitelist oracles
+
+- Destination: SortedOracles.addOracle
+- Data: `0xed35e46b095197da30ddffa5b91d386886d5ce0d`, `0xff6e35c6119742fd1eb3db780d976c4e55585108`)
+- Value: 0
+
+4. Whitelist oracles
+
+- Destination: SortedOracles.addOracle
+- Data: `0xed35e46b095197da30ddffa5b91d386886d5ce0d`, `0x59eac333453279e71a3a98b4b72bdfa99ca51ad3`)
+- Value: 0
+
+5. Whitelist oracles
+
+- Destination: SortedOracles.addOracle
+- Data: `0xed35e46b095197da30ddffa5b91d386886d5ce0d`, `0x378b95092bed2acb0d3ae6ab9c045eef1c250872`)
+- Value: 0
+
+6. Whitelist oracles
+
+- Destination: SortedOracles.addOracle
+- Data: `0xed35e46b095197da30ddffa5b91d386886d5ce0d`, `0xc5a86597d514b423579684cdf9f49b6df37e3689`)
+- Value: 0
+
+7. Whitelist oracles
+
+- Destination: SortedOracles.addOracle
+- Data: `0xed35e46b095197da30ddffa5b91d386886d5ce0d`, `0x8e1423ca0bcb15093f52d1d07675e0aa04e3da75`)
+- Value: 0
+
+8. Whitelist oracles
+
+- Destination: SortedOracles.addOracle
+- Data: `0xed35e46b095197da30ddffa5b91d386886d5ce0d`, `0xa47e6a8a7db5ee22b5293704a4f0f5f8fdaab06f`)
+- Value: 0
+
+9. Whitelist oracles
+
+- Destination: SortedOracles.addOracle
+- Data: `0xed35e46b095197da30ddffa5b91d386886d5ce0d`, `0x77d148efdd40202d0eec787073a70c7f6bc9c485`)
+- Value: 0
+
+10. Whitelist oracles
+
+- Destination: SortedOracles.addOracle
+- Data: `0xed35e46b095197da30ddffa5b91d386886d5ce0d`, `0xfef8748fd3f039fb8cfa77c7744b171f4396659c`)
+- Value: 0
+
+## Verification
+
+A human readable version of this proposal can be found using the following command (on-chain ID determined after submission):
+
+```
+celocli governance:show --proposalID <tbd>
+```
+
+## Risks
+
+This proposal carries a relatively low-risk profile as it primarily introduces new oracle rates that are currently unused. It should be checked, and confirmed however by the proposed oracle provider, that the oracle addresses listed in this proposal are correct to ensure the functioning and safety of the systems that will rely on this oracle rate in the future.
+
+## Useful Links
+
+- [Dunia launching eXOF on Celo](https://forum.celo.org/t/dunia-launching-exof-on-celo/6261)
+- [SortedOracles Smart Contract Code](https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts/stability/SortedOracles.sol)

--- a/CGPs/cgp-0098/mainnet.json
+++ b/CGPs/cgp-0098/mainnet.json
@@ -1,0 +1,62 @@
+[
+    {
+      "contract": "SortedOracles",
+      "function": "addOracle",
+      "args": ["0xed35e46b095197da30ddffa5b91d386886d5ce0d", "0xdda1d71f3d5a6090bc04b77a18925fab7054d9c3"],
+      "value": "0"
+    },
+    {
+      "contract": "SortedOracles",
+      "function": "addOracle",
+      "args": ["0xed35e46b095197da30ddffa5b91d386886d5ce0d", "0xee1d05f81e90b8ece440de6141282404e83830ce"],
+      "value": "0"
+    },
+    {
+      "contract": "SortedOracles",
+      "function": "addOracle",
+      "args": ["0xed35e46b095197da30ddffa5b91d386886d5ce0d", "0xff6e35c6119742fd1eb3db780d976c4e55585108"],
+      "value": "0"
+    },
+    {
+      "contract": "SortedOracles",
+      "function": "addOracle",
+      "args": ["0xed35e46b095197da30ddffa5b91d386886d5ce0d", "0x59eac333453279e71a3a98b4b72bdfa99ca51ad3"],
+      "value": "0"
+    },
+    {
+      "contract": "SortedOracles",
+      "function": "addOracle",
+      "args": ["0xed35e46b095197da30ddffa5b91d386886d5ce0d", "0x378b95092bed2acb0d3ae6ab9c045eef1c250872"],
+      "value": "0"
+    },
+    {
+      "contract": "SortedOracles",
+      "function": "addOracle",
+      "args": ["0xed35e46b095197da30ddffa5b91d386886d5ce0d", "0xc5a86597d514b423579684cdf9f49b6df37e3689"],
+      "value": "0"
+    },
+    {
+      "contract": "SortedOracles",
+      "function": "addOracle",
+      "args": ["0xed35e46b095197da30ddffa5b91d386886d5ce0d", "0x8e1423ca0bcb15093f52d1d07675e0aa04e3da75"],
+      "value": "0"
+    },
+    {
+      "contract": "SortedOracles",
+      "function": "addOracle",
+      "args": ["0xed35e46b095197da30ddffa5b91d386886d5ce0d", "0xa47e6a8a7db5ee22b5293704a4f0f5f8fdaab06f"],
+      "value": "0"
+    },
+    {
+      "contract": "SortedOracles",
+      "function": "addOracle",
+      "args": ["0xed35e46b095197da30ddffa5b91d386886d5ce0d", "0x77d148efdd40202d0eec787073a70c7f6bc9c485"],
+      "value": "0"
+    },
+    {
+      "contract": "SortedOracles",
+      "function": "addOracle",
+      "args": ["0xed35e46b095197da30ddffa5b91d386886d5ce0d", "0xfef8748fd3f039fb8cfa77c7744b171f4396659c"],
+      "value": "0"
+    }
+]


### PR DESCRIPTION
New CGP to whitelist some additional oracles which will be used for the launch of eXOF. This new PR takes over the existing Draft PR https://github.com/celo-org/governance/pull/332 as Nina is currently OOO and I can't make edits to her branch directly.