### PR TITLE
CGP 102: Add RedStone as an oracle provider for Mento

### DIFF
--- a/CGPs/cgp-0102.md
+++ b/CGPs/cgp-0102.md
@@ -1,0 +1,63 @@
+---
+cgp: 102
+title: Adding RedStone as oracle provider
+date-created: 2023-09-28
+author: 'Matt Gurbiel (@mattgurbiel, matt@redstone.finance)'
+---
+## Overview
+This proposal is to enable [RedStone](https://redstone.finance/) as one of the oracle providers for [Mento](https://docs.celo.org/celo-codebase/protocol/stability/doto#what-is-mento). RedStone would deliver price data for CELO/USD, CELO/EUR, CELO/BRL, USDC/USD, USDC/EUR, USDC/BRL, EUROC/EUR.
+
+## Background
+
+**About RedStone**
+
+[RedStone](https://redstone.finance/) is a novel Oracle for projects in need of flexible data feeds with frequent update time (<10 sec) - usually, it resonates well with Lending Protocols, Perpetual DEXes, Liquidity Management, Stablecoin protocols and projects responding to market trends. We’ve been live since March 2022, securing hundreds of millions of USD on mainnets. Audited by ABDK, PeckShield and independent auditors.
+We are now cooperating with some of the most important protocols in the web3 ecosystem, including Lido, Venus, Pendle, Gamma, Swell, Stader, Raft, Gearbox, DeltaPrime, Angle, Sommelier and many more. The company is backed by [top VC funds](https://twitter.com/redstone_defi/status/1564553885695373312), including Blockchain Capital, Distributed Global, Lemniscap or Coinbase Ventures as well as [prominent Builders](https://twitter.com/redstone_defi/status/1661024722690379778) such as Stani Kulechov (Founder of Aave), Sandeep Nailwal (Co-Founder Polygon), Emin Gün Sirer (Co-Founder Avalanche), Alex Gluchovski (Co-Founder zkSync) and others.
+
+**RedStone on Celo**
+
+RedStone is no stranger to the Celo ecosystem: 
+* RedStone [won the Interoperability track](https://devpost.com/software/redstone-oracle-on-celo) at Celo Make Crypto Mobile 2021 hackathon and has been incubated in the Celo Camp program,
+* RedStone co-sponsored one of the 2022 Celo hackathons, with submissions such as [Cashout](https://he-s3.s3.amazonaws.com/media/sprint/celo-hackathon/team/1579490/e343c23cashout_pitchdeck.pdf) ([Demo](https://drive.google.com/file/d/1Oxmd0XB62XxKfqRDfVnKJB2LBil7fog4/view)) and [Sarau](https://he-s3.s3.amazonaws.com/media/sprint/celo-hackathon/team/1577575/743c218sarau.pdf) ([Demo](https://www.youtube.com/watch?v=MaNPwQCCjwE&ab_channel=IsraelBuzaym)),
+* RedStone has been successfully running and testing a relayer compatible with Celo's SortedOracles on Alfajores since March 2023,
+* RedStone Core has been available for dApps since March 2022.
+
+**RedStone and Mento**
+
+At RedStone we have been staying very hands-on with the Mento Team as well as the newest developments to the protocol and we want to continue to do so. The goal is to actively support Mento’s path to further decentralization and maximal security. 
+Today we would like to open the discussion about adding RedStone to Mento’s SortedOracles Interface. 
+We also look at this proposal as laying the foundation for potential future cooperation, especially in adding security and resilience to Mento’s oracle setup.
+
+**Value RedStone brings to the table** 
+* **Most importantly - Increased security**:
+Nodes operating in standard oracle networks do not publicly reveal their Data Sources and Data Aggregation methodology. RedStone offers a different approach, focusing on transparency in terms of Data Sources and Data Aggregation methods as well as adjusting these parameters to Mento’s specific use case and risk profile.
+* **Increased decentralisation**:
+DeFi ecosystem is built on the premise of decentralisation & permissionless design. we are convinced that adding more redundancy on that front is essential. Including more high-quality providers in the oracle suite means more decentralisation in such a crucial area as pricing data.
+* **Tailoring the Oracle Infrastructure to Mento’s needs**:
+Never the other way round. RedStone focuses on custom solutions and working shoulder-to-shoulder with Builders. For Mento this would mean a lot of flexibility in terms of integration e.g. a spectrum of customisation options regarding off-chain and on-chain aggregation methods, as well as picking Data Providers they trust or adjusting the Heartbeat and Deviation Threshold parameters per each Price Feed. 
+* **Hands-on support**:
+We have a complete end2end approach, minimising the effort needed from the protocol’s side to finalise the integration. This includes things like dedicated support, running and maintaining custom Relayers pushing the prices on chain and other forms of making the integration and maintenance seamless.
+* **Future cooperation opportunities**:
+Making novel use cases possible, and unlocking maximal composability and capital efficiency for the Users is at the heart of what we do at RedStone. Forms of future cooperation can include working on custom data aggregation mechanisms, methods of injecting data to the chain, risk mitigation mechanisms etc. going towards the next versions of the protocol in the future.
+
+**Costs** 
+
+We propose a fixed subscription fee for the Data Access of $500/month + a fee per feed of $250/month. This amount is derived from costs analysis and covers the: 
+* gas costs of the Price Updates
+* infrastructure costs, 
+* monitoring costs, 
+* Data Providers margin.
+
+With 7 proposed fees the total cost for mento would be **$2250/month**.
+
+
+## Proposed Changes
+TBD
+
+
+## Links
+- [RedStone Website](https://redstone.finance/)
+- [Data Feeds](https://app.redstone.finance/)
+- [Docs](https://docs.redstone.finance/)
+- [Angel Round Announcement](https://twitter.com/redstone_defi/status/1661024722690379778)
+- [Seed Round Announcement](https://twitter.com/redstone_defi/status/1564553885695373312)


### PR DESCRIPTION
This proposal is to enable [RedStone](https://redstone.finance/) as one of the oracle providers for [Mento](https://docs.celo.org/celo-codebase/protocol/stability/doto#what-is-mento). RedStone would deliver price data for CELO/USD, CELO/EUR, CELO/BRL, USDC/USD, USDC/EUR, USDC/BRL, EUROC/EUR.