### PR TITLE
Create cgp-0118.md

### DIFF
--- a/CGPs/cgp-0118.md
+++ b/CGPs/cgp-0118.md
@@ -1,0 +1,41 @@
+---
+cgp: '118'
+title: 'Minting 10m cUSD from Mento Reserve in six tranches'
+date-created: 2024-02-23
+author: 'LuukDAO(@LuukDAO)'
+status: 'PROPOSED'
+discussions-to: 'https://forum.celo.org/t/minting-10m-cusd-from-mento-reserve-in-six-tranches/7458/1'
+governance-proposal-id: 'TBA'
+date-executed: 'TBA'
+---
+<!-- Please view another completed proposal for reference on filling the above section. It is important the type is correct eg Number, String -->
+ 
+ 
+## Background
+On Thursday, February 15th, there was a final Celo Governance call related to CGP115 in which several Stakeholders articulated their belief that we’re in a “bull market” which will result in digital assets appreciating and, as such, argued that it’s not smart for the Celo Community Treasury to convert the proposed amount of CELO into cUSD in a single transaction, but instead suggested a timeframe of six months.
+
+As such, this proposal shapes up a straightforward pathway to settle the cUSD mint in six equal monthly tranches utilizing the 30-day average on the transfer day.
+
+If passed, this proposal would overwrite the calculation of the CELO to be returned by the Mento Reserve as articulated in CGP115.
+
+Important Note: This proposal influences the number of CELO to be returned to the Celo Community Treasury from the Mento Reserve. This proposal does NOT acquire any alternative asset, such as BTC or ETH, for the Celo Community Treasury.
+ 
+## Proposed Changes
+This proposal will replace the average price of CELO for the cUSD mint in CGP115 with a new process that subtracts $1,666,667 worth of CELO using the 30-day average based on the daily open prices fetched from the CoinGecko API on the day of transfers in six equal tranches, starting with the transfer of February 16th, 2024.
+
+To realize this, the following steps have to be taken.
+
+The first tranche of February 16th will be settled using the 30-day average price of CELO from that day.
+For the coming five months, the Mento Reserve will remove the equivalent of $1,666,667 worth of CELO using the 30-day average from the CELO to be returned by the Mento Reserve.
+The resulting amount to be returned, i.e., 95M CELO minus the total of the monthly CELO amounts, will then be returned by the Mento Reserve whenever called for by Celo Governance.
+An  [overview of the Tranches and the 30-day moving average of the first tranche](https://docs.google.com/spreadsheets/d/1C7AynpmqsY8zL-M8jZw6mbIMkj5JC21Zr-WWGwhI5wI/edit?usp=sharing) (Feb 16th) have been added to the Mento Reserve Sheet.
+
+## Verification
+No on-chain changes are needed as the CELO to be returned from the Mento Reserve is tracked off-chain. 
+
+## Risks
+Overwriting the Mento Reserve mint of CGP115 exposes the Celo Community Treasury to market forces and will only have a net-positive result if the average CELO settlement price of the six tranches is higher than the 30-day moving average taken on January 22nd ($0.748).
+
+## Useful Links
+- [CGP115](https://forum.celo.org/t/celo-governance-development-sprint-ahead-of-cel2/6742)
+- [Community Treasury Status and Diversification Options](https://forum.celo.org/t/community-treasury-status-and-diversification-options/7451)


### PR DESCRIPTION
This proposal is a direct follow-up on CGP115. It aims to settle the 10m cUSD mint from the Mento Reserve in six monthly tranches using the 30-day average instead of the current accepted flow that minted all in one transaction using the 30-day average of January 22nd, 2024.