### PR TITLE
CGP123: MU05 - Add native USDC pools to Mento v2

### DIFF
--- a/CGPs/cgp-0123/cgp-0123.md
+++ b/CGPs/cgp-0123/cgp-0123.md
@@ -25,7 +25,7 @@ Check the [forum post](https://forum.celo.org/t/proposal-mento-upgrade-mu05-nati
 
 ## Risks
 
-This is a relatively low risk proposal as it only involves adding new pools to the Mento v2 protocol. Trading limits of the existing axlUSDC pools have also been adjusted to keep the same FX risk profile of the Mento Reserve. The proposal has been thoroughly tested by the Mento team in testnet environments and in a celo mainnet like fork.
+This is a relatively low risk proposal as it only involves adding new pools to the Mento v2 protocol. Trading limits of the existing axlUSDC pools have also been adjusted to keep the same FX risk profile of the Mento Reserve. The proposal has been thoroughly tested by the Mento team in testnet environments and in a Celo mainnet like fork.
 
 ## Useful Links
 

--- a/CGPs/cgp-0123/cgp-0123.md
+++ b/CGPs/cgp-0123/cgp-0123.md
@@ -1,0 +1,34 @@
+---
+cgp: 123
+title: MU05 - Add native USDC pools to Mento v2
+date-created: 2024-03-007
+author: "Nelson Taveras <nelson.taveras@mentolabs.xyz>, Philip Rätsch <philip.raetsch@mentolabs.xyz>"
+status: DRAFT
+discussions-to: https://forum.celo.org/t/proposal-mento-upgrade-mu05-native-usdc-integration/7545
+governance-proposal-id: "TBA"
+date-executed: "TBA"
+---
+
+## Overview
+
+This proposal would like to introduce additional native USDC pools in Mento v2 to provide a more efficient and secure way to access USDC liquidity on Celo. Concretely, it proposes the addition of three new pools: cUSD/nativeUSDC, cEUR/nativeUSDC and cBRL/nativeUSDC. These new pools will at first coexist with the existing axlUSDC pools and will eventually fully replace them, to remove the now unnecessary bridge dependency. In addition, the proposal also includes an update to the trading limits of the existing axlUSDC pools in order for the Mento Reserve to keep the same FX risk profile accross all USDC related pools.
+
+An in-depth description of the governance proposal aimed at approvers and developers can be found in the [forum post](https://forum.celo.org/t/proposal-mento-upgrade-mu05-native-usdc-integration/7545).
+
+## Proposed Changes
+
+Check the [forum post](https://forum.celo.org/t/proposal-mento-upgrade-mu05-native-usdc-integration/7545) for a detailed description of the proposed changes.
+
+## Verification
+
+Check the [forum post](https://forum.celo.org/t/proposal-mento-upgrade-mu05-native-usdc-integration/7545) for a detailed description of verification steps.
+
+## Risks
+
+This is a relatively low risk proposal as it only involves adding new pools to the Mento v2 protocol. Trading limits of the existing axlUSDC pools have also been adjusted to keep the same FX risk profile of the Mento Reserve. The proposal has been thoroughly tested by the Mento team in testnet environments and in a celo mainnet like fork.
+
+## Useful Links
+
+- [MU05 CGP Forum Post](https://forum.celo.org/t/proposal-mento-upgrade-mu05-native-usdc-integration/7545)
+- [Circle's USDC deployed on Celo](https://blog.celo.org/now-live-circles-usdc-deploys-on-celo-mainnet-a98ddca9e53a)
+- [Mento Docs](https://docs.mento.org)


### PR DESCRIPTION
This adds CGP123 which introduces additional native USDC pools to Mento v2. 

See previos forum discussion: https://forum.celo.org/t/proposal-mento-upgrade-mu05-native-usdc-integration/7545