### PR TITLE
Add CGP-0134: Validators rewards - changes in epoch parameters

### DIFF
--- a/CGPs/cgp-0134.md
+++ b/CGPs/cgp-0134.md
@@ -1,0 +1,108 @@
+---
+cgp: 0134
+title: "Validators rewards - changes in epoch parameters"
+date-created: 2024-05-04
+author: '@Thylacine @Roman @Patrick @Dee>'
+status: DRAFT
+discussions-to: https://forum.celo.org/t/draft-validators-rewards-change-in-epoch-parameters/7702
+governance-proposal-id: TBD
+date-executed: 0000-00-00 - <ISO 8601 (yyyy-mm-dd) if executed, or empty>
+---
+ 
+## Overview
+
+This proposal seeks support to change the epoch parameters in Celo. The reason is that the validator rewards have gone down by 56%, the annual rewards are close to $33k and it continues to further go down. 
+ 
+The situation is not sustainable. Many of the small independent validators are coming from the Baklava Stake Off organised in 2019. The hardware requirement has more than quadrupled, all the business operation costs have gone up and maintaining a secured 24/7 operation in a high inflationary environment with regulation uncertainty is a challenge for many of us.
+ 
+## Background Information
+The chain was launched with 600m Celo at genesis in April 2020. The remaining 400m were reserved for epoch rewards. These epoch rewards are currently going to voting rewards, validator rewards, community fund and carbon offset fund. 
+
+If we look at the circulating supply, we have a total of 690m Celo so that means that the chain has created new 90m Celo since genesis. This means our annual inflation rate has been less than 3.6% and current network inflation rate is 2.09%. There are about 40k new Celo minted daily. By looking at the code, there was supposed to be a linear reward of 200m over 15 years so that’s about 36.5k Celo per epoch and 13.3m Celo per year. 
+
+As per the initial token release schedule, the community fund would have received 171m Celo over the span of 30 years. There was an assumption that if there are low voting rewards then people would not lock their Celo and this could be a security risk but reality is that people have been rather insensitive to the voting rewards and very few people know the current rewards. The community fund is set to receive a total of an extra 120m Celo from the Mento reserve.
+
+## Proposed Changes
+ 
+This proposal is to revert back and freeze the reward multiplier to its previous value two years ago. The following changes will be implemented:
+- Reward multiplier will be freezed and re-adjusted to 0.78. This will stabilize validators rewards around $58.5k
+- To account for the total of 150m Celo being transferred from Mento, this proposal will significally cut down the emissions to the community fund
+- We will freeze the emission to locked voting Celo at its current rate. This will have the advantage of maintaining consistent yield and prevent further decreased that has occurend in the past for the locked voting Celo
+
+
+```
+[
+    {
+      "contract": "EpochRewards",
+      "function": "setRewardsMultiplierParameters",
+      "args": [
+        "2000000000000000000000000",
+        "0",
+        "0"
+      ],
+      "value": "0"
+    },
+    {
+        "contract": "EpochRewards",
+        "function": "setTargetVotingYield",
+        "args": [
+            "101500000000000000000"
+        ],
+        "value": "0"
+    },
+    {
+        "contract": "EpochRewards",
+        "function": "setTargetVotingYieldParameters",
+        "args": [
+            "500000000000000000000",
+            "0"
+        ],
+        "value": "0"
+    },
+    {
+        "contract": "EpochRewards",
+        "function": "setCommunityRewardFraction",
+        "args": [
+            "10000000000000000000000"
+        ],
+        "value": "0"
+    }
+]
+```
+
+These changes have been tested on Alfajores testnet 
+
+## Verification
+
+This command should show the proposal:
+
+celocli governance:show --proposalID 175 --node https://forno.celo.org
+
+
+## Risks
+
+The contract change is regarded as low risk as this proposal only changes the value of the different parameters without changing the underlying logic. The stability and safety of these changes have been confirmed on testnet. 
+
+This proposal aims to complement the Retroactive Validator Rewards Program #1 that was put forward shortly afterwards. As a result, the reward multiplier has been deliberately kept below 1 to maintain balance during this transitional phase.
+
+This proposal serves as a temporary measure to provide relief to the validator community. However, it is crucial that we engage in a broader and more comprehensive discussion concerning the reward and incentive structures affecting all stakeholders (Validators, Celo holders and even stablecoin holders). This discussion is especially pertinent as we prepare for the transition to Layer 2, which may necessitate a reevaluation of our overall tokenomics to ensure long-term sustainability for the protocol economics. 
+
+## Useful Links
+
+Multiple discussions have been held around this topic over the course of 4 years:
+* April 2024: [[FINAL] Retroactive Validator Rewards Program #1 | QF and RPGF Rounds](https://forum.celo.org/t/final-retroactive-validator-rewards-program-1-qf-and-rpgf-rounds/7889)
+* April 2021: [Long-term incentives and Celo’s deflationary model](https://forum.celo.org/t/long-term-incentives-and-celos-deflationary-model/840)
+* June 2021: [Discussion on Validator Rewards](https://forum.celo.org/t/discussion-on-validator-rewards/1163)
+* June 2021: [Discussion on Celo Epoch Rewards](https://forum.celo.org/t/discussion-on-celo-epoch-rewards/1105)
+* Oct 2021: [Validator Rewards: Rewarded in Celo or cUSD](https://forum.celo.org/t/validator-rewards-rewarded-in-celo-or-cusd/1442)
+* Aug 2022: [Reopen discussion - Validator Rewards](https://forum.celo.org/t/reopen-discussion-validator-rewards/4082)
+
+Miscellaneous:
+* [How to get information on Epoch Rewards](https://forum.celo.org/t/celo-explorer-epoch-rewards-data-now-available/4948)
+* [Link to Epoch Rewards code for the Celo protocol](https://github.com/celo-org/celo-monorepo/blob/master/packages/protocol/contracts/governance/EpochRewards.sol)
+* [Mento Reserve: Returning CELO](https://forum.celo.org/t/mento-reserve-returning-celo/5236)
+* [Increase of Minimum Gas Fee](https://forum.celo.org/t/increase-of-minimum-gas-fee/4616)
+* [Increase of Minimum Gas Fee - Part II](https://forum.celo.org/t/increase-of-minimum-gas-fee-part-ii/4947)
+* [Paying the bills… Celo’s Financials?](https://forum.celo.org/t/paying-the-bills-celos-financials/3720)
+* [Long-term incentives and Celo’s deflationary model](https://forum.celo.org/t/long-term-incentives-and-celos-deflationary-model/840)
+

--- a/CGPs/cgp-0134/alfajores.json
+++ b/CGPs/cgp-0134/alfajores.json
@@ -1,0 +1,37 @@
+[
+    {
+      "contract": "EpochRewards",
+      "function": "setRewardsMultiplierParameters",
+      "args": [
+        "2000000000000000000000000",
+        "0",
+        "0"
+      ],
+      "value": "0"
+    },
+    {
+        "contract": "EpochRewards",
+        "function": "setTargetVotingYield",
+        "args": [
+            "101500000000000000000"
+        ],
+        "value": "0"
+    },
+    {
+        "contract": "EpochRewards",
+        "function": "setTargetVotingYieldParameters",
+        "args": [
+            "500000000000000000000",
+            "0"
+        ],
+        "value": "0"
+    },
+    {
+        "contract": "EpochRewards",
+        "function": "setCommunityRewardFraction",
+        "args": [
+            "10000000000000000000000"
+        ],
+        "value": "0"
+    }
+]

--- a/CGPs/cgp-0134/mainnet.json
+++ b/CGPs/cgp-0134/mainnet.json
@@ -1,0 +1,37 @@
+[
+    {
+      "contract": "EpochRewards",
+      "function": "setRewardsMultiplierParameters",
+      "args": [
+        "2000000000000000000000000",
+        "0",
+        "0"
+      ],
+      "value": "0"
+    },
+    {
+        "contract": "EpochRewards",
+        "function": "setTargetVotingYield",
+        "args": [
+            "101500000000000000000"
+        ],
+        "value": "0"
+    },
+    {
+        "contract": "EpochRewards",
+        "function": "setTargetVotingYieldParameters",
+        "args": [
+            "500000000000000000000",
+            "0"
+        ],
+        "value": "0"
+    },
+    {
+        "contract": "EpochRewards",
+        "function": "setCommunityRewardFraction",
+        "args": [
+            "10000000000000000000000"
+        ],
+        "value": "0"
+    }
+]


### PR DESCRIPTION
This PR is created to help @dee submit his governance proposal to increase validator rewards in line close to where they were originally set at genesis. This is also utilizing the payload created and tested in #425 