### PR TITLE
[cgp-134] add missing payload parameter

### DIFF
--- a/CGPs/cgp-0134.md
+++ b/CGPs/cgp-0134.md
@@ -65,6 +65,13 @@ As per the initial token release schedule, the community fund would have receive
             "10000000000000000000000"
         ],
         "value": "0"
+    },{
+        "contract": "EpochRewards",
+        "function": "setTargetValidatorEpochPayment",
+        "args": [
+            "160273972602739000000"
+        ],
+        "value": "0"
     }
 ]
 ```


### PR DESCRIPTION
The readme was missing a payload parameter. This rectifies the issue and makes the correct payload parameters visible on the readme. Subsequently, visible on the 3rd party applications like celo.stake.id