### PR TITLE
Updating CGP-0157 mainnet to include comma in the proper place

### DIFF
--- a/CGPs/cgp-0157/mainnet.json
+++ b/CGPs/cgp-0157/mainnet.json
@@ -4,7 +4,7 @@
       "address": "0x765DE816845861e75A25fCA122bb6898B8B1282a",
       "function": "Approve",
       "args": [
-        "0x35ff861a0b6215CeC71EA282B0D32AfefA661795"
+        "0x35ff861a0b6215CeC71EA282B0D32AfefA661795",
         "225000000000000000000000"
       ],
       "value": "0"


### PR DESCRIPTION
comma needed after the receiving address in args section , before amount to be transfered