### PR TITLE
docs: fix typo in "Oracle solutions" wording

### DIFF
--- a/CGPs/cgp-0180.md
+++ b/CGPs/cgp-0180.md
@@ -39,7 +39,7 @@ Check the [forum post](https://forum.celo.org/t/launch-new-mento-stablecoins-jpy
 
 The data relayed by the ChainlinkRelayer contract is only as secure as the Chainlink price feeds it relies on. If the Chainlink price feeds are compromised, the data relayed by the ChainlinkRelayer contract could be manipulated. This could lead to the SortedOracles contract reporting incorrect rate feeds to the rest of the protocol.
 
-This risk is present with all Oracle solution and is not specific to the Chainlink price feeds. In order to mitigate this risk, the Mento Protocol has implemented onchain circuit breakers that automatically pause the protocol if the reported data is outside of a predefined threshold. As well as our onchain trading limits, which limit the trading bandwidth.
+This risk is present with all Oracle solutions and is not specific to the Chainlink price feeds. In order to mitigate this risk, the Mento Protocol has implemented onchain circuit breakers that automatically pause the protocol if the reported data is outside of a predefined threshold. As well as our onchain trading limits, which limit the trading bandwidth.
 
 ## Useful Links
 


### PR DESCRIPTION
a typo where "Oracle solution" was used instead of "Oracle solutions" - corrected it to match the intended meaning (plural, all solutions).