### PR TITLE
Update checkout action to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   install:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: |
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [install]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
Replaced actions/checkout@v3 with actions/checkout@v4 in .github/workflows/ci.yml to keep the CI setup up to date and follow GitHub's latest recommended practices.

Why:
Latest v4 includes improvements, security patches, and better performance.
GitHub official release: https://github.com/actions/checkout/releases/tag/v4.0.0

Clean and future-proof.