### PR TITLE
Update CGP156

### DIFF
--- a/CGPs/cgp-0156.md
+++ b/CGPs/cgp-0156.md
@@ -3,9 +3,9 @@ cgp: 156
 title: Enabling MENTO Governance
 date-created: 2024-11-25
 author: "Bogdan Dumitru <bogdan@mentolabs.xyz>, Roman Croessmann <roman@mentolabs.xyz>, Markus Franke <markus@mentolabs.xyz>"
-status: DRAFT
+status: PROPOSED
 discussions-to: https://forum.celo.org/t/finalize-mento-governance-transition-and-return-celo-to-the-community/9526
-governance-proposal-id:
+governance-proposal-id: 235
 date-executed:
 ---
 
@@ -51,8 +51,6 @@ This CGP now completes the transfer of governance over the Mento Protocol on the
   - GrandaMento + GrandaMentoProxy
 - Mento Governance contracts:
   - GovernanceFactory
-
-A Mento-related smart contract that will remain under CELO governance is the [SortedOracles contract](https://explorer.celo.org/mainnet/address/0x35a4f0C8C0B48769F036b79F9d428BeA286f6ab5). This was requested by core Celo engineers and is due to the fact that the contract is used in similar parts by Celo and Mento core contracts.
 
 This proposal also fulfills the remaining obligation of the Mento Reserve in returning the CELO it received in the Genesis Block initiated in [CGP 79](https://mondo.celo.org/governance/cgp-79) and executed in part in CGP 79 (25M CELO returned) and [GGP 118](https://mondo.celo.org/governance/cgp-118) (12.593M CELO returned) by returning the remaining 85.9M CELO to the Celo Community Fund. This proposal directly sends 20M CELO to the Celo Governance Proxy and transfers the remaining 65.9M CELO to a newly deployed Custody Reserve contract configured for Celo Governance, enabling the community to control the timing of future CELO withdrawals. This 20/65.9 split was suggested by the CeloPG Stewards based on anticipated ecosystem spending.
 


### PR DESCRIPTION
This updates CGP156 with two things:

- Removes a paragraph from the proposal that was left over by mistake stating that sortedOracles wouldn't be transferred in the proposal (should have been removed as part of https://github.com/celo-org/governance/pull/646 but I didn't notice it at the time)
- As the on-chain proposal id