### PR TITLE
cgp-0233: CELOccelerate tokenomics temperature check

### DIFF
--- a/CGPs/cgp-0233.md
+++ b/CGPs/cgp-0233.md
@@ -1,5 +1,5 @@
 ---
-cgp: 234
+cgp: 233
 title: "CELOccelerate: Celo Tokenomics Proposal (Temperature Check)"
 date-created: 2026-04-07
 author: "Celo Core Co."
@@ -52,7 +52,7 @@ Celo Core Co. has collected approximately 1.749M CELO in sequencer fees since th
 
 This is a one-time action that signals a clear principle: sequencer revenue belongs to the community, not to Celo Core Co. Going forward, the mechanism described above ensures this is true by default.
 
-The executable burn proposal is tracked separately as **CGP-0233**.
+The executable burn proposal is tracked separately as **CGP-0234**.
 
 ## 3. Minimum Base Fee Increase
 
@@ -96,7 +96,7 @@ Each of the four directions, if supported by this temperature check, will be fol
 | # | Direction | Follow-up CGP |
 | --- | --- | --- |
 | 1 | Route net sequencer revenue + stablecoin conversion to Community Fund | TBD |
-| 2 | Burn 1,748,950 CELO already returned to the Community Fund | **CGP-0233** |
+| 2 | Burn 1,748,950 CELO already returned to the Community Fund | **CGP-0234** |
 | 3 | Programmatic minimum base fee increases post-Jovian | TBD (Security Council 6/8) |
 | 4 | Pause Carbon Offset Fund contributions for five years | TBD |
 
@@ -121,4 +121,4 @@ We welcome community feedback and discussion prior to onchain submission.
 ## Useful Links
 
 - [CELOccelerate: Celo Tokenomics Proposal (forum)](https://forum.celo.org/t/celoccelerate-celo-tokenomics-proposal/13147/1)
-- [CGP-0233 — Burn 1,748,950 CELO Returned to the Community Fund](./cgp-0233.md)
+- [CGP-0234 — Burn 1,748,950 CELO Returned to the Community Fund](./cgp-0234.md)

--- a/CGPs/cgp-0234.md
+++ b/CGPs/cgp-0234.md
@@ -1,0 +1,124 @@
+---
+cgp: 234
+title: "CELOccelerate: Celo Tokenomics Proposal (Temperature Check)"
+date-created: 2026-04-07
+author: "Celo Core Co."
+status: DRAFT
+discussions-to: https://forum.celo.org/t/celoccelerate-celo-tokenomics-proposal/13147/1
+governance-proposal-id:
+date-executed:
+---
+
+> **This is a temperature check proposal.** It contains **no on-chain transactions**. Its purpose is to gauge community sentiment on the CELOccelerate tokenomics direction before any binding, executable proposals are submitted. A "Yes" vote signals support for the four changes outlined below; a "No" vote signals opposition; an "Abstain" vote contributes to quorum without taking a position.
+
+## Overview
+
+Today, Celo Core Co. is excited to celebrate the network's one-year anniversary as an L2, and propose a set of coordinated changes that turn network growth into CELO value, ensuring that the protocol's economic model keeps pace with its adoption.
+
+Celo was built to create real-world impact at global scale. The network now processes over 700K daily active transactions, powers stablecoin payments across emerging markets through MiniPay, and has become one of the most-used chains in the world. But while usage has grown substantially, protocol revenue and token economics haven't kept up.
+
+That changes now. With Celo's transition to an Ethereum L2 complete and the Jovian hardfork on the horizon, the infrastructure is in place to build a durable economic model — one where every transaction on Celo strengthens CELO.
+
+## Proposal Summary
+
+This temperature check asks the community to weigh in on **four** coordinated changes:
+
+1. **Route all net sequencer revenue to the Community Fund as CELO**, including programmatic conversion of stablecoin fees into CELO on the open market.
+2. **Return and burn the first year of sequencer fees**, sending 1.749M CELO collected since the L2 migration to the Community Fund and initiating a governance proposal to burn it.
+3. **Increase the minimum base fee in a measured, programmatic cadence following the Jovian hardfork.**
+4. **Pause Carbon Offset Fund contributions for five years**, given a 25x surplus relative to annual emissions.
+
+## 1. Sequencer Revenue to CELO Holders
+
+Celo's L2 architecture generates sequencer revenue. Today, that revenue sits with cLabs. This proposal changes that.
+
+After covering core protocol operating costs (OP Stack, EigenDA, Succinct, and carbon offsets while applicable), all remaining sequencer revenue will be used to acquire CELO and send it to the Community Fund.
+
+The Community Fund is governed by CELO holders through onchain governance. Sending revenue there puts it directly in the hands of token holders, who can decide whether to hold, reinvest, or burn.
+
+### Stablecoin Fee Conversion
+
+Thanks to Celo's fee abstraction, up to 50% of gas fees are paid in USDT and other stablecoins. Under this proposal, those stablecoin fees will be programmatically converted into CELO on the open market before being transferred to the Community Fund.
+
+This is a feature unique to Celo. Fee abstraction doesn't just make the chain easier to use — it becomes a source of consistent, programmatic buy pressure for CELO, directly tied to real network activity.
+
+### Governance Retains Control
+
+Rather than hardcoding a buyback-and-burn, this proposal routes purchased CELO to the Community Fund and lets governance decide what happens next. The community may choose to burn. It may choose to reinvest in ecosystem growth. The structure preserves value accrual while keeping CELO holders in control.
+
+## 2. Retroactive Burn
+
+Celo Core Co. has collected approximately 1.749M CELO in sequencer fees since the L2 migration. We are returning all of it to the Community Fund and initiating a separate governance proposal to burn the full amount.
+
+This is a one-time action that signals a clear principle: sequencer revenue belongs to the community, not to Celo Core Co. Going forward, the mechanism described above ensures this is true by default.
+
+The executable burn proposal is tracked separately as **CGP-0233**.
+
+## 3. Minimum Base Fee Increase
+
+Celo's network usage has grown substantially, but protocol revenue has not scaled proportionally. Fees remain well below levels that users would meaningfully notice. There is room to improve revenue capture without introducing friction.
+
+The upcoming Jovian hardfork transitions Celo to Optimism's configurable Minimum Base Fee standard, making it possible to adjust the fee floor programmatically without future hardforks. Following Jovian activation, we propose to begin increasing the minimum base fee:
+
+- **Cadence**: base fee increases every week for eight to ten weeks
+- **Execution**: via the Celo Core Co. portion of the Security Council (6/8)
+- **Approach**: incremental, not a single large adjustment
+
+The guiding principle is simple: increase protocol revenue where there is room to do so, without introducing friction for users. At current fee levels, these adjustments are expected to remain negligible from the user's perspective.
+
+Celo will continue to prioritize low-cost transactions and accessibility. We will actively monitor CELO price, average transaction fees, and network usage. If fees begin to approach levels that could negatively affect adoption, the pace of adjustments will be slowed or paused. The goal is not to extract more from users — it is to responsibly capture value from a network that is already generating it.
+
+## 4. Pause Carbon Offset Fund Contributions
+
+Celo has been carbon-negative since launch. That commitment isn't changing. But the numbers tell us we can be smarter about capital allocation.
+
+The Carbon Offset Fund currently holds approximately **25x** the network's annual emissions. Pre-L2, Celo produced roughly 563 tCO2 per year. Post-L2, the emissions profile is materially lower. We propose pausing new contributions for **five years**. Celo will continue operating carbon-negative using the existing surplus, with emissions and coverage ratios reviewed annually.
+
+This frees up capital for the mechanisms described above while preserving the environmental commitment that makes Celo distinct.
+
+## Expected Impact
+
+Together, these changes create a flywheel:
+
+- More usage generates more sequencer revenue
+- More revenue means more CELO acquired and sent to the Community Fund
+- A stronger Community Fund supports ecosystem growth and token value
+- Stronger token economics attract more builders and users
+
+Celo has already proven that real-world adoption at scale is possible. Now the opportunity is to make sure that growth isn't only visible in usage metrics, but reflected in the economic strength of the network itself.
+
+## Proposed Changes
+
+**No on-chain changes.** This is a temperature check proposal.
+
+Each of the four directions, if supported by this temperature check, will be followed by separate executable CGPs:
+
+| # | Direction | Follow-up CGP |
+| --- | --- | --- |
+| 1 | Route net sequencer revenue + stablecoin conversion to Community Fund | TBD |
+| 2 | Burn 1,748,950 CELO already returned to the Community Fund | **CGP-0233** |
+| 3 | Programmatic minimum base fee increases post-Jovian | TBD (Security Council 6/8) |
+| 4 | Pause Carbon Offset Fund contributions for five years | TBD |
+
+## Verification
+
+This command should show no transactions:
+
+```bash
+celocli governance:show --proposalID <PROPOSAL_ID> --node https://forno.celo.org
+```
+
+## Risks
+
+As there are no on-chain actions performed at the time of executing this proposal, no technical risks arise in the short term. The risks of the underlying directions will be addressed in their respective follow-up executable CGPs.
+
+## Thank You
+
+Celo wouldn't be where it is without the validators, builders, governance participants, and community members who have helped grow the network into one of the most widely used chains in the world. This proposal builds on that foundation and sets CELO up for its next phase.
+
+We welcome community feedback and discussion prior to onchain submission.
+
+## Useful Links
+
+- [CELOccelerate: Celo Tokenomics Proposal (forum)](https://forum.celo.org/t/celoccelerate-celo-tokenomics-proposal/13147/1)
+- [CGP-0233 — Burn 1,748,950 CELO Returned to the Community Fund](./cgp-0233.md)


### PR DESCRIPTION
## Summary

- Adds **CGP-0234** as a **temperature check** for the [CELOccelerate](https://forum.celo.org/t/celoccelerate-celo-tokenomics-proposal/13147/1) tokenomics direction.
- **No on-chain transactions** — this proposal exists to gauge community sentiment before any binding, executable proposals are submitted.
- Asks the community to weigh in on four coordinated changes:
  1. **Route all net sequencer revenue to the Community Fund as CELO**, including programmatic conversion of stablecoin fees into CELO on the open market.
  2. **Return and burn the first year of sequencer fees** (1.749M CELO) — the executable burn is tracked separately as **CGP-0233**.
  3. **Increase the minimum base fee** in a measured, programmatic cadence following the Jovian hardfork.
  4. **Pause Carbon Offset Fund contributions for five years**, given the existing 25x surplus relative to annual emissions.

## Files

- `CGPs/cgp-0234.md` — temperature check proposal text (no JSON; no on-chain transactions)

## Test plan

- [ ] No on-chain verification needed — temperature check has no transactions.
- [ ] Verify the proposal renders correctly on `mondo.celo.org` and the Celo governance UI once submitted.
- [ ] Confirm `celocli governance:show --proposalID <id>` shows zero transactions after on-chain submission.

## Related

- CGP-0233 (executable burn of the 1.749M CELO retroactive return) — [#797](https://github.com/celo-org/governance/pull/797)
- Forum discussion: https://forum.celo.org/t/celoccelerate-celo-tokenomics-proposal/13147/1