### PR TITLE
cgp-0233: clarify base fee authority and follow-up CGP scope

### DIFF
--- a/CGPs/cgp-0233.md
+++ b/CGPs/cgp-0233.md
@@ -25,7 +25,7 @@ This temperature check asks the community to weigh in on **four** coordinated ch
 
 1. **Route all net sequencer revenue to the Community Fund as CELO**, including programmatic conversion of stablecoin fees into CELO on the open market.
 2. **Return and burn the first year of sequencer fees**, sending 1.749M CELO collected since the L2 migration to the Community Fund and initiating a governance proposal to burn it.
-3. **Increase the minimum base fee in a measured, programmatic cadence following the Jovian hardfork.**
+3. **Increase the minimum base fee in a measured, programmatic cadence following the Jovian hardfork, by delegating base fee setting authority to the following 6/8 multisig 0x9Eb44Da23433b5cAA1c87e35594D15FcEb08D34d managed by the Celo Core Co. team.**
 4. **Pause Carbon Offset Fund contributions for five years**, given a 25x surplus relative to annual emissions.
 
 ## 1. Sequencer Revenue to CELO Holders
@@ -61,7 +61,7 @@ Celo's network usage has grown substantially, but protocol revenue has not scale
 The upcoming Jovian hardfork transitions Celo to Optimism's configurable Minimum Base Fee standard, making it possible to adjust the fee floor programmatically without future hardforks. Following Jovian activation, we propose to begin increasing the minimum base fee:
 
 - **Cadence**: base fee increases every week for eight to ten weeks
-- **Execution**: via the Celo Core Co. portion of the Security Council (6/8)
+- **Execution**: via the Celo Core Co. portion of the Security Council, a 6/8 multisig at the following address: 0x9Eb44Da23433b5cAA1c87e35594D15FcEb08D34d
 - **Approach**: incremental, not a single large adjustment
 
 The guiding principle is simple: increase protocol revenue where there is room to do so, without introducing friction for users. At current fee levels, these adjustments are expected to remain negligible from the user's perspective.
@@ -91,14 +91,12 @@ Celo has already proven that real-world adoption at scale is possible. Now the o
 
 **No on-chain changes.** This is a temperature check proposal.
 
-Each of the four directions, if supported by this temperature check, will be followed by separate executable CGPs:
+Some components of this proposal require separate CGPs that include onchain transactions:
 
 | # | Direction | Follow-up CGP |
 | --- | --- | --- |
-| 1 | Route net sequencer revenue + stablecoin conversion to Community Fund | TBD |
-| 2 | Burn 1,748,950 CELO already returned to the Community Fund | **CGP-0234** |
-| 3 | Programmatic minimum base fee increases post-Jovian | TBD (Security Council 6/8) |
-| 4 | Pause Carbon Offset Fund contributions for five years | TBD |
+| 1 | Burn 1,748,950 CELO already returned to the Community Fund | **CGP-0234** |
+| 2 | Pause Carbon Offset Fund contributions for five years | TBD |
 
 ## Verification
 


### PR DESCRIPTION
## Summary
- Specify that base fee setting authority is delegated to the Celo Core Co. 6/8 multisig (`0x9Eb44Da23433b5cAA1c87e35594D15FcEb08D34d`)
- Update the follow-up CGP table to only list components that require separate onchain CGPs (burn + Carbon Offset Fund pause)

## Test plan
- [ ] Verify rendered markdown on GitHub
- [ ] Confirm multisig address is correct