### PR TITLE
cgp-0236: avoid leaving leftover 10% burn on the contract, handle burn off-chain

### DIFF
--- a/CGPs/cgp-0236.md
+++ b/CGPs/cgp-0236.md
@@ -42,6 +42,24 @@ It pauses the fee-based carbon fund distributions on the FeeHandler (currently 1
 
 Sets the carbon fraction to 0. The freed fraction is redirected to the burn (since `burnFraction = 1 - carbonFraction - otherBeneficiariesFraction`). There is one other beneficiary on mainnet (`0x7A1E98FC9a008107DbD1f430a05Ace8cf6f3FE19`), so `totalFractionOfOtherBeneficiariesAndCarbon` remains non-zero and no division-by-zero can occur in `_distribute()`.
 
+### Transaction 2: Remove cLabs Other Beneficiary
+
+- **Destination**: `FeeHandler` at `0xcD437749E43A154C07F3553504c68fBfD56B8778`
+- **Function**: `removeOtherBeneficiary(address)`
+- **Args**: `["0x7A1E98FC9a008107DbD1f430a05Ace8cf6f3FE19"]`
+- **Value**: 0
+
+Removes cLabs as an other beneficiary so its allocation can be re-added at 100% in the next transaction. This indirection is required because `changeOtherBeneficiaryAllocation` cannot raise an existing allocation past the available headroom — see [celo-monorepo#11735](https://github.com/celo-org/celo-monorepo/issues/11735).
+
+### Transaction 3: Re-add cLabs at 100%
+
+- **Destination**: `FeeHandler` at `0xcD437749E43A154C07F3553504c68fBfD56B8778`
+- **Function**: `addOtherBeneficiary(address,uint256,string)`
+- **Args**: `["0x7A1E98FC9a008107DbD1f430a05Ace8cf6f3FE19", "1000000000000000000000000", "cLabs"]`
+- **Value**: 0
+
+Re-adds cLabs as the sole other beneficiary at 100% (`1e24` in Fixidity fixed point). After this transaction the burn fraction is 0 and all distributed fees flow to cLabs.
+
 ### Json Script
 
 See [mainnet.json](cgp-0236/mainnet.json).

--- a/CGPs/cgp-0236/mainnet.json
+++ b/CGPs/cgp-0236/mainnet.json
@@ -11,7 +11,6 @@
   },
   {
     "contract": "FeeHandler",
-    "address": "0xcD437749E43A154C07F3553504c68fBfD56B8778",
     "function": "removeOtherBeneficiary",
     "args": [
       "0x7A1E98FC9a008107DbD1f430a05Ace8cf6f3FE19"
@@ -21,7 +20,6 @@
   },
   {
     "contract": "FeeHandler",
-    "address": "0xcD437749E43A154C07F3553504c68fBfD56B8778",
     "function": "addOtherBeneficiary",
     "args": [
       "0x7A1E98FC9a008107DbD1f430a05Ace8cf6f3FE19",

--- a/CGPs/cgp-0236/mainnet.json
+++ b/CGPs/cgp-0236/mainnet.json
@@ -8,5 +8,27 @@
     ],
     "value": "0",
     "description": "Set the carbon fraction to 0 on FeeHandler, pausing fee-based carbon fund payments. The freed fraction is redirected to the burn."
+  },
+  {
+    "contract": "FeeHandler",
+    "address": "0xcD437749E43A154C07F3553504c68fBfD56B8778",
+    "function": "removeOtherBeneficiary",
+    "args": [
+      "0x7A1E98FC9a008107DbD1f430a05Ace8cf6f3FE19"
+    ],
+    "value": "0",
+    "description": "Remove cLabs as an other beneficiary so its allocation can be re-added at 100% in the next step. Required because changeOtherBeneficiaryAllocation cannot raise an existing allocation past the available headroom — see https://github.com/celo-org/celo-monorepo/issues/11735."
+  },
+  {
+    "contract": "FeeHandler",
+    "address": "0xcD437749E43A154C07F3553504c68fBfD56B8778",
+    "function": "addOtherBeneficiary",
+    "args": [
+      "0x7A1E98FC9a008107DbD1f430a05Ace8cf6f3FE19",
+      "1000000000000000000000000",
+      "cLabs"
+    ],
+    "value": "0",
+    "description": "Re-add cLabs as the sole other beneficiary at 100%. After this step the burn fraction is 0 and all distributed fees flow to cLabs."
   }
 ]


### PR DESCRIPTION
Adds two transactions to CGP-0236 so distributed fees go fully to cLabs after carbon is paused: `removeOtherBeneficiary(cLabs)` then `addOtherBeneficiary(cLabs, 100%, "cLabs")`. Workaround for [celo-monorepo#11735](https://github.com/celo-org/celo-monorepo/issues/11735).