### PR TITLE
cgp-0237: Allow CICLOPS to complete withdrawal of Season 2 funding

### DIFF
--- a/CGPs/cgp-0237.md
+++ b/CGPs/cgp-0237.md
@@ -15,7 +15,7 @@ This proposal addresses an earlier discrepancy in CGP 202, which used the `appro
 
 This CGP addresses both issues by:
 
-1. Increasing the CELO allowance for the CICLOPS multisig by 697,777 CELO so that the withdrawable balance matches the Community Fund's current CELO balance (9,669,452 CELO).
+1. Increasing the CELO allowance for the CICLOPS multisig by 697,777 CELO. This brings the total CELO allowance to 9,669,452 CELO (`8,971,675 + 697,777`), which corresponds to the Community Fund's CELO balance at the time of drafting.
 2. Increasing the USDm allowance for the CICLOPS multisig by $101,298 to cover the remaining shortfall (~1,199,693 CELO at the price used in the original calculation of $0.08445).
 
 The total value withdrawn remains within the originally approved Season 1 and Season 2 budgets.

--- a/CGPs/cgp-0237.md
+++ b/CGPs/cgp-0237.md
@@ -1,0 +1,94 @@
+---
+cgp: 237
+title: Allow CICLOPS to Complete Withdrawal of Season 2 Funding
+date-created: 2026-04-27
+author: 'Nauman Mustafa (@nauman)'
+status: DRAFT
+discussions-to: https://forum.celo.org/t/celo-infrastructure-for-chain-lifecycle-operational-support-ciclops-season-2-funding-request
+governance-proposal-id:
+date-executed:
+---
+
+Proposal Description
+============================
+This proposal addresses an earlier discrepancy in CGP 202, which used the `approve` function instead of `increaseAllowance` and overwrote a remaining allowance of 1,897,470 CELO. As a result, CICLOPS should be able to withdraw 10,869,143 CELO today, but the on-chain allowance is only 8,971,675 CELO. In addition, CICLOPS was approved in Season 2 (CGP 231) to withdraw 21,738,286 CELO. To date, CICLOPS has withdrawn the first half of its approved allocation in accordance with the forum post. The remaining withdrawal of 10,869,143 CELO cannot be fully executed because the Community Fund currently holds approximately 9,669,452 CELO.
+
+This CGP addresses both issues by:
+
+1. Increasing the CELO allowance for the CICLOPS multisig by 697,777 CELO so that the withdrawable balance matches the Community Fund's current CELO balance (9,669,452 CELO).
+2. Increasing the USDm allowance for the CICLOPS multisig by $101,298 to cover the remaining shortfall (~1,199,693 CELO at the price used in the original calculation of $0.08445).
+
+The total value withdrawn remains within the originally approved Season 1 and Season 2 budgets.
+
+Read the full proposal and discussion on the [forum post](https://forum.celo.org/t/celo-infrastructure-for-chain-lifecycle-operational-support-ciclops-season-2-funding-request).
+
+Specifications
+============================
+This proposal:
+- Increases the CELO allowance for the CICLOPS multisig by 697,777 CELO to account for part of the delta that was overwritten by CGP 202.
+- Approves a USDm allowance of $101,298 for the CICLOPS multisig to cover the CELO shortfall in the Community Fund.
+
+This proposal does not:
+- Approve any new or additional funding beyond what was already approved in CGP 202 and CGP 231.
+- Change the total approved budget allocated for Seasons 1 and 2.
+- Alter the scope, governance, or oversight structure of CICLOPS.
+
+Proposed Changes
+============================
+## Transaction Descriptions
+1. Increase CELO allowance for CICLOPS multisig by 697,777 CELO
+   - Destination: GoldToken (`0x471EcE3750Da237f93B8E339c536989b8978a438`)
+   - Data: `increaseAllowance(spender = 0xd71efa410B6EaAB0bAc3b515B393C886BE70F09E, value = 697777000000000000000000)`
+   - Value: 0
+
+2. Increase USDm allowance for CICLOPS multisig by $101,298
+   - Destination: USDm / StableToken (`0x765de816845861e75a25fca122bb6898b8b1282a`)
+   - Data: `increaseAllowance(spender = 0xd71efa410B6EaAB0bAc3b515B393C886BE70F09E, value = 101298000000000000000000)`
+   - Value: 0
+
+## Json Script
+```json
+[
+  {
+    "contract": "GoldToken",
+    "function": "increaseAllowance",
+    "args": [
+      "0xd71efa410B6EaAB0bAc3b515B393C886BE70F09E",
+      "697777000000000000000000"
+    ],
+    "value": "0"
+  },
+  {
+    "contract": "StableToken",
+    "function": "increaseAllowance",
+    "args": [
+      "0xd71efa410B6EaAB0bAc3b515B393C886BE70F09E",
+      "101298000000000000000000"
+    ],
+    "value": "0"
+  }
+]
+```
+
+Verification
+============================
+A human readable version of this proposal can be found using the following command (on-chain ID determined after submission):
+
+`$ celocli governance:show --proposalID xxx --node https://forno.celo.org`
+
+Risks
+============================
+This proposal does not deploy or upgrade contracts or change network parameters and represents minimal risk to the network.
+
+As with CGP 231, the approval mechanism means funds are not transferred directly but rather an allowance is granted for the CICLOPS multisig to pull. Funds will not be lost if the approval address contains a typo.
+
+USDm is the Mento stablecoin formerly known as cUSD, a native Celo stablecoin pegged to the US dollar.
+
+## Multisig
+CICLOPS 3-of-5 multisig: `0xd71efa410B6EaAB0bAc3b515B393C886BE70F09E`
+
+Useful Links
+============================
+- [Forum Post](https://forum.celo.org/t/celo-infrastructure-for-chain-lifecycle-operational-support-ciclops-season-2-funding-request)
+- [CGP 202 — CICLOPS Season 1 funding](./cgp-0202.md)
+- [CGP 231 — CICLOPS Season 2 funding](./cgp-0231.md)

--- a/CGPs/cgp-0237.md
+++ b/CGPs/cgp-0237.md
@@ -18,7 +18,7 @@ This CGP addresses both issues by:
 1. Increasing the CELO allowance for the CICLOPS multisig by 697,777 CELO. This brings the total CELO allowance to 9,669,452 CELO (`8,971,675 + 697,777`), which corresponds to the Community Fund's CELO balance at the time of drafting.
 2. Increasing the USDm allowance for the CICLOPS multisig by $101,298 to cover the remaining shortfall (~1,199,693 CELO at the price used in the original calculation of $0.08445).
 
-The total value withdrawn remains within the originally approved Season 1 and Season 2 budgets.
+The total dollar value made available to CICLOPS through Seasons 1, 2, and this proposal equals the originally approved Season 1 and Season 2 budgets, with the CELO shortfall covered in USDm at the reference price of $0.08445.
 
 Read the full proposal and discussion on the [forum post](https://forum.celo.org/t/celo-infrastructure-for-chain-lifecycle-operational-support-ciclops-season-2-funding-request).
 

--- a/CGPs/cgp-0237/mainnet.json
+++ b/CGPs/cgp-0237/mainnet.json
@@ -1,0 +1,20 @@
+[
+  {
+    "contract": "GoldToken",
+    "function": "increaseAllowance",
+    "args": [
+      "0xd71efa410B6EaAB0bAc3b515B393C886BE70F09E",
+      "697777000000000000000000"
+    ],
+    "value": "0"
+  },
+  {
+    "contract": "StableToken",
+    "function": "increaseAllowance",
+    "args": [
+      "0xd71efa410B6EaAB0bAc3b515B393C886BE70F09E",
+      "101298000000000000000000"
+    ],
+    "value": "0"
+  }
+]


### PR DESCRIPTION
## Summary
- Adds CGP 237 proposal addressing the CICLOPS Season 2 withdrawal shortfall caused by CGP 202 overwriting a remaining CELO allowance via `approve` instead of `increaseAllowance`.
- Increases the CICLOPS multisig CELO allowance by 697,777 CELO (bringing it to the Community Fund's current balance) and grants a USDm allowance of \$101,298 to cover the ~1,199,693 CELO shortfall at the original \$0.08445 reference price.
- Does not approve new funding — total dollar value across Seasons 1, 2, and this proposal equals the originally approved budgets.

## Test plan
- [ ] Verify `CGPs/cgp-0237/mainnet.json` matches the transactions described in `CGPs/cgp-0237.md`
- [ ] Confirm CICLOPS multisig address `0xd71efa410B6EaAB0bAc3b515B393C886BE70F09E`
- [ ] Confirm GoldToken (`0x471EcE3750Da237f93B8E339c536989b8978a438`) and USDm/StableToken (`0x765de816845861e75a25fca122bb6898b8b1282a`) destinations
- [ ] Confirm allowance amounts (697,777 CELO and \$101,298 USDm) match the forum post math