### PR TITLE
cgp-0240: Enable USA₮ and XAU₮0 (Tether Gold) as Gas Currencies

### DIFF
--- a/CGPs/cgp-0240.md
+++ b/CGPs/cgp-0240.md
@@ -1,0 +1,145 @@
+---
+cgp: 240
+title: Enable USA₮ and XAU₮0 (Tether Gold) as Gas Currencies
+date-created: 2026-05-18
+author: 'Pavel Hornak (@pahor167)'
+status: DRAFT
+discussions-to: https://forum.celo.org/t/enable-usa-and-xau-0-as-gas-currencies-on-celo/13162
+governance-proposal-id:
+date-executed:
+---
+
+## Overview
+
+This proposal adds two new gas fee currencies on Celo using the same `FeeCurrencyWrapper` adapter pattern Tether already uses for USDT0:
+
+| Token | FeeCurrencyWrapper (proxy) | Implementation | Rate path |
+|---|---|---|---|
+| **USA₮** — Tether's regulated US-dollar stablecoin | `0x0357EE22278c922e1D36cFe6b899269b161880C4` | `0xACc6EFBE554397b741baadecf0120780b858f5f4` | CELO/cUSD (equivalent-token mapping) |
+| **XAU₮0** — Tether Gold (omnichain) | `0x857BF24e29da0773687E804a743c2E421a394C16` | (Tether-deployed FeeWrapper) | CELO/XAUt via a `ChainlinkRelayerV1` (CELO/USD × inverse(XAUt/USDT)) |
+
+Both wrappers use [Celo's Token Adapter Pattern](https://docs.celo.org/protocol/transaction/erc20-transaction-fees#tokens-with-adapters) and expose the `debitGasFees` / `creditGasFees` interface required by op-geth. Once registered, holders can pay transaction fees directly in USA₮ or XAU₮0 without acquiring a separate gas token. USA₮ follows the precedent set by USDT ([CGP-0128](./cgp-0128.md)) and USDC ([CGP-0127](./cgp-0127.md)); XAU₮0 follows the precedent set by WETH ([CGP-0203](./cgp-0203.md)) — the first non-stablecoin volatile asset as a gas currency.
+
+### USA₮ rate routing
+
+USA₮ is a USD-pegged stablecoin trading at ≈ \$1. As with USDT (CGP-0128) and USDGLO ([CGP-0190](./cgp-0190.md)), the CELO/USA₮ rate is derived by mapping the wrapper to cUSD via `SortedOracles.setEquivalentToken`, so the protocol reuses the existing CELO/cUSD median as the CELO/USA₮ rate. No new oracle relayer is required for USA₮.
+
+### XAU₮0 rate routing
+
+The CELO/XAU₮ rate is derived using a `ChainlinkRelayerV1` (from `mento-protocol/mento-core` v2.5.0, byte-identical to the existing WETH relayer):
+
+| # | Feed | Address | Invert | Provider | Deviation | Heartbeat |
+|---|------|---------|--------|----------|-----------|-----------|
+| 0 | CELO/USD   | `0x0568fD19986748cEfF3301e55c0eb1E729E0Ab7e` | `false` | Chainlink | 0.5% | 240s |
+| 1 | XAUt/USDT  | `0x98DC6E90D4c2f212ed9d124aD2aFBa4833268633` | `true`  | Redstone  | 0.1% | 86,400s |
+
+**Derivation**: `CELO/USD × inverse(XAUt/USDT) ≈ CELO/XAUt`
+
+The relayer is deployed at `0xEd2e6f192aD96B1676C6167aB27949179e08CBD1` and pushes rates to `SortedOracles` keyed by the rate-feed id `0xb1C735FFd1b8F01316382E72bcc17D19493eB009` (`keccak("relayed:CELOXAUt")[12:32]`). The XAU₮0 wrapper is then mapped to that rate-feed id via `SortedOracles.setEquivalentToken`.
+
+### Intrinsic gas
+
+Both wrappers are the same `FeeCurrencyWrapper` contract type, so their gas profile for `creditGasFees` + `debitGasFees` is expected to match USDT's. We adopt **85,000** for both — the value set for USDT in [CGP-0230](./cgp-0230.md) based on mainnet measurements (median 84,125 gas, max 84,200 gas across 5,000 transactions). A follow-up CGP can adjust either value via `FeeCurrencyDirectory.setCurrencyConfig` if measurements diverge.
+
+### Prerequisite: Mento Governance Proposal (live on Mento Governor)
+
+`SortedOracles` (`0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33`) is governed by the Mento DAO, not the Celo Governance proxy, so the oracle-side setup for both tokens is executed by a Mento governance proposal rather than this CGP.
+
+The matching Mento proposal has already been submitted on mainnet and is currently active for voting:
+
+- **Mento Governor:** `0x47036d78bB3169b4F5560dD77BF93f4412A59852`
+- **Proposal ID:** `71584103760601111736732521846624098660436473330261456937699703019294404182777`
+- **Mento UI:** https://governance.mento.org/proposals/71584103760601111736732521846624098660436473330261456937699703019294404182777
+- **Proposer:** `0x1b07d2B31bE2c6ee7639A06Dcf66281C3bd58714`
+
+It performs four transactions on `SortedOracles`, all verified byte-identical to the proposal's on-chain `ProposalCreated` event:
+
+1. `addOracle(rateFeedId = 0xb1C735FFd1b8F01316382E72bcc17D19493eB009, oracle = 0xEd2e6f192aD96B1676C6167aB27949179e08CBD1)` — register the CELO/XAU₮ `ChainlinkRelayerV1`.
+2. `setTokenReportExpiry(rateFeedId = 0xb1C735FFd1b8F01316382E72bcc17D19493eB009, expiry = 360)` — match the WETH precedent.
+3. `setEquivalentToken(token = 0x857BF24e29da0773687E804a743c2E421a394C16 XAU₮0 FeeWrapper, equivalentToken = 0xb1C735FFd1b8F01316382E72bcc17D19493eB009)` — route XAU₮0 to the rate feed.
+4. `setEquivalentToken(token = 0x0357EE22278c922e1D36cFe6b899269b161880C4 USA₮ FeeCurrencyWrapper, equivalentToken = 0x765DE816845861e75A25fCA122bb6898B8B1282a cUSD)` — reuse CELO/cUSD for USA₮.
+
+This CGP must not be queued until the Mento proposal has executed; otherwise `FeeCurrencyDirectory.getExchangeRate` for either wrapper will revert.
+
+## Proposed Changes
+
+### Transaction Descriptions
+
+1. **Enable USA₮ FeeCurrencyWrapper as gas currency**
+   - Destination: `FeeCurrencyDirectory.setCurrencyConfig`
+   - Data:
+     - token = `0x0357EE22278c922e1D36cFe6b899269b161880C4` (USA₮ FeeCurrencyWrapper)
+     - oracle = `0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33` (SortedOracles)
+     - intrinsicGas = `85000`
+   - Value: 0
+
+2. **Add USA₮ FeeCurrencyWrapper to the FeeHandler**
+   - Destination: `FeeHandler.addToken`
+   - Data:
+     - tokenAddress = `0x0357EE22278c922e1D36cFe6b899269b161880C4` (USA₮ FeeCurrencyWrapper)
+     - handlerAddress = `0xD3aeE28548Dbb65DF03981f0dC0713BfCBd10a97` (UniswapFeeHandlerSeller)
+   - Value: 0
+
+3. **Enable XAU₮0 FeeWrapper as gas currency**
+   - Destination: `FeeCurrencyDirectory.setCurrencyConfig`
+   - Data:
+     - token = `0x857BF24e29da0773687E804a743c2E421a394C16` (XAU₮0 FeeWrapper)
+     - oracle = `0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33` (SortedOracles)
+     - intrinsicGas = `85000`
+   - Value: 0
+
+4. **Add XAU₮0 FeeWrapper to the FeeHandler**
+   - Destination: `FeeHandler.addToken`
+   - Data:
+     - tokenAddress = `0x857BF24e29da0773687E804a743c2E421a394C16` (XAU₮0 FeeWrapper)
+     - handlerAddress = `0xD3aeE28548Dbb65DF03981f0dC0713BfCBd10a97` (UniswapFeeHandlerSeller)
+   - Value: 0
+
+The `handlerAddress` is the canonical `UniswapFeeHandlerSeller` used by USDT, USDC, and WETH (CGP-0196, CGP-0203). The `FeeHandler` requires it to be non-zero to handle the token correctly.
+
+### Json Script
+
+See [mainnet.json](cgp-0240/mainnet.json).
+
+## Verification
+
+```bash
+celocli governance:show --proposalID TBD --node https://forno.celo.org
+```
+
+Key addresses:
+
+- **USA₮ FeeCurrencyWrapper**: `0x0357EE22278c922e1D36cFe6b899269b161880C4` — proxy; impl `0xACc6EFBE554397b741baadecf0120780b858f5f4` verified on CeloScan as `FeeCurrencyWrapper`, deployer "Tether: Deployer 1".
+- **XAU₮0 FeeWrapper**: `0x857BF24e29da0773687E804a743c2E421a394C16` — adapter wrapping XAU₮0 for Celo fee-currency compatibility.
+- **SortedOracles**: `0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33` — the well-known oracle contract used by all fee currencies. Owned by the Mento multisig `0x58099b74f4acd642da77b4b7966b4138ec5ba458`.
+- **FeeCurrencyDirectory**: `0x15F344b9E6c3Cb6F0376A36A64928b13F62C6276` — owned by the Celo Governance proxy (`0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972`), so this CGP can mutate it.
+- **FeeHandler**: `0xcD437749E43A154C07F3553504c68fBfD56B8778` — also owned by Celo Governance.
+- **UniswapFeeHandlerSeller**: `0xD3aeE28548Dbb65DF03981f0dC0713BfCBd10a97` — the canonical fee handler seller used by USDT, USDC, WETH.
+- **cUSD**: `0x765DE816845861e75A25fCA122bb6898B8B1282a` — equivalent-token target for USA₮.
+- **CELO/XAU₮ relayer**: `0xEd2e6f192aD96B1676C6167aB27949179e08CBD1` — `ChainlinkRelayerV1`, byte-identical to the WETH relayer.
+- **CELO/XAU₮ rate feed id**: `0xb1C735FFd1b8F01316382E72bcc17D19493eB009` — `keccak("relayed:CELOXAUt")[12:32]`.
+- **Chainlink CELO/USD feed**: `0x0568fD19986748cEfF3301e55c0eb1E729E0Ab7e` — same feed used by the WETH relayer.
+- **Redstone XAUt/USDT feed**: `0x98DC6E90D4c2f212ed9d124aD2aFBa4833268633` — Redstone multi-feed adapter on Celo mainnet.
+
+## Risks
+
+- **Execution ordering:** This CGP depends on the Mento prerequisite (MGP-17) landing first. If this CGP executes before MGP-17, `FeeCurrencyDirectory.getExchangeRate` for either wrapper will revert until MGP-17 executes.
+- **Peg risk (USA₮):** USA₮ is a fiat-backed stablecoin pegged to \$1; CELO/cUSD ≈ CELO/USA₮ holds while USA₮ holds peg. A sustained depeg would mis-price gas, an existing risk shared by USDT, USDC, cUSD, USDGLO.
+- **Oracle availability (XAU₮0):** XAU₮0's gas price depends on the Chainlink CELO/USD and Redstone XAUt/USDT feeds being fresh. The 360 s report expiry must be honoured by a regular `relay()` call; if either underlying feed stalls beyond `maxTimestampSpread` (86,400 s), the relayer reverts and the cached rate ages out.
+- **Price volatility (XAU₮0):** XAU₮ tracks gold, historically less volatile than ETH. Comparable or lower magnitude risk than the existing WETH gas currency.
+- **FeeCurrencyWrapper contract:** Both adapters must correctly implement `creditGasFees` and `debitGasFees`. The implementations are the same `FeeCurrencyWrapper` contract type Tether uses for USDT0 on Celo, verified on CeloScan.
+- **Intrinsic gas calibration:** 85,000 mirrors USDT's post-CGP-0230 value. If either wrapper's measured gas consumption diverges, a follow-up CGP can adjust per token via `FeeCurrencyDirectory.setCurrencyConfig`.
+
+## Useful Links
+
+- [Forum discussion: Enable USA₮ and XAU₮0 as Gas Currencies on Celo](https://forum.celo.org/t/enable-usa-and-xau-0-as-gas-currencies-on-celo/13162)
+- [Adding Gas Currencies to Celo](https://docs.celo.org/learn/add-gas-currency)
+- [Paying for Gas with Tokens](https://docs.celo.org/what-is-celo/about-celo-l1/protocol/transaction/erc20-transaction-fees)
+- [Token Adapter Pattern](https://docs.celo.org/protocol/transaction/erc20-transaction-fees#tokens-with-adapters)
+- [CGP-0128: Enable USDT as Gas Currency](./cgp-0128.md)
+- [CGP-0196: Add USDC and USDT to the FeeHandler contract](./cgp-0196.md)
+- [CGP-0203: Adding WETH as gas currency](./cgp-0203.md)
+- [CGP-0211: Setting WETH oracle for gas pricing](./cgp-0211.md)
+- [CGP-0230: Increase Intrinsic Gas for USDT and USDC Fee Currencies](./cgp-0230.md)
+- [Mento ChainlinkRelayerV1](https://github.com/mento-protocol/mento-core/blob/v2.5.0/contracts/oracles/ChainlinkRelayerV1.sol)
+- [Redstone Celo Multi-Feed Config](https://github.com/redstone-finance/redstone-oracles-monorepo/blob/main/packages/relayer-remote-config/main/relayer-manifests-multi-feed/celoMultiFeed.json)

--- a/CGPs/cgp-0240/mainnet.json
+++ b/CGPs/cgp-0240/mainnet.json
@@ -1,0 +1,44 @@
+[
+  {
+    "contract": "FeeCurrencyDirectory",
+    "function": "setCurrencyConfig",
+    "args": [
+      "0x0357EE22278c922e1D36cFe6b899269b161880C4",
+      "0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33",
+      85000
+    ],
+    "value": "0",
+    "description": "Register USA₮ FeeCurrencyWrapper as gas currency with SortedOracles (oracle) and intrinsicGas matching USDT (CGP-0230). Requires Mento governance prerequisite MGP-17: SortedOracles.setEquivalentToken(USA₮ wrapper, cUSD)."
+  },
+  {
+    "contract": "FeeHandler",
+    "function": "addToken",
+    "args": [
+      "0x0357EE22278c922e1D36cFe6b899269b161880C4",
+      "0xD3aeE28548Dbb65DF03981f0dC0713BfCBd10a97"
+    ],
+    "value": "0",
+    "description": "Add USA₮ FeeCurrencyWrapper to FeeHandler with the canonical UniswapFeeHandlerSeller as handler."
+  },
+  {
+    "contract": "FeeCurrencyDirectory",
+    "function": "setCurrencyConfig",
+    "args": [
+      "0x857BF24e29da0773687E804a743c2E421a394C16",
+      "0xefB84935239dAcdecF7c5bA76d8dE40b077B7b33",
+      85000
+    ],
+    "value": "0",
+    "description": "Register XAU₮0 FeeWrapper as gas currency with SortedOracles (oracle) and intrinsicGas matching USDT. Requires Mento governance prerequisite MGP-17: addOracle + setTokenReportExpiry + setEquivalentToken(XAU₮0 wrapper, CELO/XAUt rateFeedId)."
+  },
+  {
+    "contract": "FeeHandler",
+    "function": "addToken",
+    "args": [
+      "0x857BF24e29da0773687E804a743c2E421a394C16",
+      "0xD3aeE28548Dbb65DF03981f0dC0713BfCBd10a97"
+    ],
+    "value": "0",
+    "description": "Add XAU₮0 FeeWrapper to FeeHandler with the canonical UniswapFeeHandlerSeller as handler."
+  }
+]


### PR DESCRIPTION
## Summary
- Adds CGP-0240 — registers two new Tether-issued `FeeCurrencyWrapper` tokens as gas currencies on Celo: **USA₮** (`0x0357EE22…80C4`, routed to cUSD via `setEquivalentToken`) and **XAU₮0 / Tether Gold** (`0x857BF24E…4C16`, routed via a Chainlink CELO/USD × inverse(Redstone XAUt/USDT) `ChainlinkRelayerV1`).
- Four Celo Governance transactions: `FeeCurrencyDirectory.setCurrencyConfig` + `FeeHandler.addToken` for each wrapper. `intrinsicGas = 85000` both (matches USDT post-CGP-0230).
- Depends on a Mento Governance prerequisite — `SortedOracles` is owned by the Mento Safe `0x58099B74…` (transferred via MGP-14, 2026-03-01). The live Mento Governor proposal `71584103760601111…` carries the four required `SortedOracles` calls; Safe signers execute them per MGP-14's "subsequent proposals" clause.

## Discussion
Forum: <https://forum.celo.org/t/enable-usa-and-xau-0-as-gas-currencies-on-celo/13162>
Mento prerequisite proposal: <https://governance.mento.org/proposals/71584103760601111736732521846624098660436473330261456937699703019294404182777>