### PR TITLE
cgp-0240: resubmit as proposal #294 (Mento prerequisite re-submitted)

### DIFF
--- a/CGPs/cgp-0240.md
+++ b/CGPs/cgp-0240.md
@@ -1,16 +1,16 @@
 ---
 cgp: 240
-title: "[Withdrawn - vote no] Enable USA₮ and XAU₮0 (Tether Gold) as Gas Currencies"
+title: Enable USA₮ and XAU₮0 (Tether Gold) as Gas Currencies
 date-created: 2026-05-18
 author: 'Pavel Hornak (@pahor167)'
-status: WITHDRAWN
+status: PROPOSED
 discussions-to: https://forum.celo.org/t/enable-usa-and-xau-0-as-gas-currencies-on-celo/13162
-governance-proposal-id:
+governance-proposal-id: 294
 date-executed:
 ---
 
 ## Update:
-As [MGP-18](https://governance.mento.org/proposals/71584103760601111736732521846624098660436473330261456937699703019294404182777) has no passed, this proposal is not viable at this time and has to be withdrawn.
+The Mento governance prerequisite has been [re-submitted on Mento governance](https://governance.mento.org/proposals/112339692544100114229468165282409962931431701913866170915723287810681223839121) (currently active for voting). This CGP is re-submitted as on-chain proposal [#294](https://mondo.celo.org/governance/294) and will only become executable once the Mento proposal passes and is executed.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- Reverts the prior "Withdrawn" state of CGP-0240 — the Mento governance prerequisite has been re-submitted (proposal `112339692544100114229468165282409962931431701913866170915723287810681223839121`, currently active for voting).
- This CGP has been re-submitted on Celo Governance as on-chain proposal [#294](https://mondo.celo.org/governance/294).
- `status` → `PROPOSED`, `governance-proposal-id` → `294`, title cleaned of the "[Withdrawn - vote no]" prefix.
- `## Update:` block rewritten to point to the new active Mento proposal and the new on-chain id.

Transactions in `CGPs/cgp-0240/mainnet.json` are unchanged from the originally merged version.

## Test plan

- [ ] CGP frontmatter validates (`yarn validate`)
- [ ] Mento proposal `112339...839121` is observed Active on `governance.mento.org`
- [ ] On-chain proposal #294 visible on `mondo.celo.org/governance/294`
- [ ] Once Mento proposal executes, re-run `./CGPs/cgp-0240/test-cgp-0240-lifecycle.sh` against a fork