### PR TITLE
cgp-0241: Contracts Release 17

### DIFF
--- a/CGPs/cgp-0241.md
+++ b/CGPs/cgp-0241.md
@@ -1,0 +1,116 @@
+---
+cgp: 241
+title: Contracts Release 17
+date-created: 2026-06-16
+author: "Pavel Hornak (@pahor167)"
+status: PROPOSED
+discussions-to: https://forum.celo.org/t/validator-group-voter-reward-commission/13392
+governance-proposal-id:
+date-executed:
+---
+
+## Overview
+
+In this governance proposal, we propose to execute the Celo Core Contracts Release 17. This release follows the standard [release process](https://docs.celo.org/community/release-process/smart-contracts).
+
+The main part of this release is the introduction of a maximum voter reward commission for validator groups, motivated and discussed in [this forum post](https://forum.celo.org/t/validator-group-voter-reward-commission/13392). The `Validators` contract is upgraded to support this parameter, and the proposal sets it to 100% (see [Transactions additional to contract changes](#transactions-additional-to-contract-changes)).
+
+Changes that are being proposed are described in [this Github release](https://github.com/celo-org/celo-monorepo/releases/tag/core-contracts.v17). The tooling provided ensures the version control references included in the report match the contract deployment described in the proposal content.
+
+## Proposed Changes
+
+Updated contract(s):
+1. `Election`: `1.2.0.0` ⇒ `1.2.0.1`
+2. `EpochManager`: `1.1.0.3` ⇒ `1.2.0.0`
+3. `Validators`: `1.4.0.0` ⇒ `1.4.1.0`
+
+New contracts:
+
+N/A
+
+Deprecated contracts:
+
+N/A
+
+## Transactions
+
+1. Set the new `Election` implementation
+   - Destination: `ElectionProxy._setImplementation`
+   - Data: implementation `0x74f9e5ee4071b9b35d127000a20f8e964009cb57`
+   - Value: 0 CELO; this is an implementation update and does not transfer funds
+
+2. Set the new `EpochManager` implementation
+   - Destination: `EpochManagerProxy._setImplementation`
+   - Data: implementation `0xf31beee5e104bf62fb14f783ca31cddaaddea788`
+   - Value: 0 CELO; this is an implementation update and does not transfer funds
+
+3. Set the new `Validators` implementation
+   - Destination: `ValidatorsProxy._setImplementation`
+   - Data: implementation `0x13b0b89f3242f815c1fc6c9cf56e1ab5aea4dc58`
+   - Value: 0 CELO; this is an implementation update and does not transfer funds
+
+## Transactions additional to contract changes
+
+In addition to the contract implementation updates above, this release sets the maximum voter reward commission on the `Validators` contract. This change does not represent a change to the current release schedule.
+
+4. Set the maximum voter reward commission to 100%
+   - Destination: `ValidatorsProxy.setMaxVoterRewardCommission` at `0xaEb865bCa93DdC8F47b8e29F40C5399cE34d0C58` (the `Validators` proxy)
+   - Data: amount `1000000000000000000000000` (1e24 in FixidityLib fixed-point, i.e. 100%)
+   - Value: 0 CELO; this is a parameter update and does not transfer funds
+
+## Verification
+
+### Smart Contracts
+
+#### Dependencies
+
+1. CeloCLI, can be installed with `$ npm install -g @celo/celocli@latest`
+2. Foundry toolset:
+   1. Install the version manager with `$ curl -L https://foundry.paradigm.xyz | bash` (after you need to restart your terminal or run `source ~/.bashrc / source ~/.zshrc`)
+   2. Install foundry itself with `foundryup`
+
+#### Code to verify
+
+Make sure to download latest [celo-monorepo](https://github.com/celo-org/celo-monorepo/) with
+
+`$ git clone git@github.com:celo-org/celo-monorepo.git --branch release/core-contracts/17`
+
+#### Build and verify
+
+Then build the project with:
+
+`$ yarn && yarn build`
+
+Once built, `cd` to the protocol folder with:
+
+`$ cd packages/protocol`
+
+From there, you can download the current proposal:
+
+```bash
+$ celocli governance:show --proposalID <PROPOSAL_ID> --jsonTransactions release-17-proposal.json --node https://forno.celo.org
+```
+
+And then verify that the proposal deployment matches the audited release:
+
+```
+$ yarn release:verify-deployed:foundry -p release-17-proposal.json -b core-contracts.v17 -n mainnet -f -i "releaseData/initializationData/release17.json"
+```
+
+The output should verify that the bytecodes and storages match what is expected, it should look something like this:
+
+```
+Success, no bytecode mismatches found!
+Writing linked library addresses to libraries.json
+✨  Done in 30.86s.
+```
+
+## Risks
+
+Celo Core Contracts are critical for the functioning of the Celo Platform. While cLabs have invested significant efforts to expand testing and verification tooling, errors in this proposal could lead to situations that are only recoverable with a very difficult hard-fork.
+
+## Useful Links
+
+- [Validator group voter reward commission — forum discussion](https://forum.celo.org/t/validator-group-voter-reward-commission/13392)
+- [Celo Core Contracts Release Process](https://docs.celo.org/community/release-process/smart-contracts)
+- [Github release notes](https://github.com/celo-org/celo-monorepo/releases/tag/core-contracts.v17)

--- a/CGPs/cgp-0241.md
+++ b/CGPs/cgp-0241.md
@@ -13,7 +13,7 @@ date-executed:
 
 In this governance proposal, we propose to execute the Celo Core Contracts Release 17. This release follows the standard [release process](https://docs.celo.org/community/release-process/smart-contracts).
 
-The main part of this release is the introduction of a maximum voter reward commission for validator groups, motivated and discussed in [this forum post](https://forum.celo.org/t/validator-group-voter-reward-commission/13392). The `Validators` contract is upgraded to support this parameter, and the proposal sets it to 100% (see [Transactions additional to contract changes](#transactions-additional-to-contract-changes)).
+The main part of this release is the introduction of the **voter reward commission** feature for validator groups, motivated and discussed in [this forum post](https://forum.celo.org/t/validator-group-voter-reward-commission/13392). This feature lets validator groups charge a commission on the rewards earned by their voters. The `Validators` contract is upgraded to support it, and the proposal sets the maximum allowed commission to 100% (see [Transactions additional to contract changes](#transactions-additional-to-contract-changes)).
 
 Changes that are being proposed are described in [this Github release](https://github.com/celo-org/celo-monorepo/releases/tag/core-contracts.v17). The tooling provided ensures the version control references included in the report match the contract deployment described in the proposal content.
 
@@ -51,7 +51,7 @@ N/A
 
 ## Transactions additional to contract changes
 
-In addition to the contract implementation updates above, this release sets the maximum voter reward commission on the `Validators` contract. This change does not represent a change to the current release schedule.
+In addition to the contract implementation updates above, this release activates the voter reward commission feature by setting the maximum allowed commission on the `Validators` contract. This change does not represent a change to the current release schedule.
 
 4. Set the maximum voter reward commission to 100%
    - Destination: `ValidatorsProxy.setMaxVoterRewardCommission` at `0xaEb865bCa93DdC8F47b8e29F40C5399cE34d0C58` (the `Validators` proxy)

--- a/CGPs/cgp-0241.md
+++ b/CGPs/cgp-0241.md
@@ -3,7 +3,7 @@ cgp: 241
 title: Contracts Release 17
 date-created: 2026-06-16
 author: "Pavel Hornak (@pahor167)"
-status: PROPOSED
+status: DRAFT
 discussions-to: https://forum.celo.org/t/validator-group-voter-reward-commission/13392
 governance-proposal-id:
 date-executed:

--- a/CGPs/cgp-0241/mainnet.json
+++ b/CGPs/cgp-0241/mainnet.json
@@ -1,0 +1,35 @@
+[
+  {
+    "contract": "ElectionProxy",
+    "function": "_setImplementation",
+    "args": [
+      "0x74f9e5ee4071b9b35d127000a20f8e964009cb57"
+    ],
+    "value": "0"
+  },
+  {
+    "contract": "EpochManagerProxy",
+    "function": "_setImplementation",
+    "args": [
+      "0xf31beee5e104bf62fb14f783ca31cddaaddea788"
+    ],
+    "value": "0"
+  },
+  {
+    "contract": "ValidatorsProxy",
+    "function": "_setImplementation",
+    "args": [
+      "0x13b0b89f3242f815c1fc6c9cf56e1ab5aea4dc58"
+    ],
+    "value": "0"
+  },
+  {
+    "contract": "ValidatorsProxy",
+    "function": "setMaxVoterRewardCommission",
+    "args": [
+      "1000000000000000000000000"
+    ],
+    "value": "0",
+    "description": "Set max voter reward commission to 100%"
+  }
+]


### PR DESCRIPTION
## Summary

Adds **CGP-0241 — Celo Core Contracts Release 17**.

Main change: introduces a **voter reward commission** for validator groups (the `Validators` contract is upgraded to support it and the proposal sets it to 100%), motivated by the [forum discussion](https://forum.celo.org/t/validator-group-voter-reward-commission/13392).

### Contract upgrades
| Contract | v16 → v17 |
|---|---|
| Election | 1.2.0.0 → 1.2.0.1 |
| EpochManager | 1.1.0.3 → 1.2.0.0 |
| Validators | 1.4.0.0 → 1.4.1.0 |

### Proposal transactions (`CGPs/cgp-0241/mainnet.json`)
1. `ElectionProxy._setImplementation`
2. `EpochManagerProxy._setImplementation`
3. `ValidatorsProxy._setImplementation`
4. `ValidatorsProxy.setMaxVoterRewardCommission` → 100% (1e24)

### Files
- `CGPs/cgp-0241.md` — proposal description
- `CGPs/cgp-0241/mainnet.json` — proposal transactions

## Notes / TODO
- `governance-proposal-id` left blank until submitted on-chain.
- Proposed-changes scope derived from the tooling-generated `proposal-mainnet-core-contracts.v17.json` on `release/core-contracts/17`; confirm against the v17 audit report once published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)