### PR TITLE
cgp-0246: Stabila Season 3 Funding Proposal

### DIFF
--- a/CGPs/cgp-0246.md
+++ b/CGPs/cgp-0246.md
@@ -1,0 +1,232 @@
+---
+cgp: 246
+title: Stabila Season 3 Funding Proposal
+date-created: 2026-07-24
+author: '@Stabila'
+status: DRAFT
+discussions-to: https://forum.celo.org/t/stabila-season-3-funding-proposal/13574
+governance-proposal-id:
+date-executed:
+---
+
+Proposal Description
+============================
+
+## Proposal Key Aspects
+
+* **Receiver Entity:** Celo Governance
+* **Status:** [DRAFT]
+* **Author(s):** @Stabila
+* **Type of Request:** Funding
+* **Funding Request:** $360,000 USD equivalent to 4,838,709.68 CELO (CELO-denominated at the 90-day trailing average CELO price of $0.0744 — April 24–July 22, 2026)
+
+## Summary
+
+This proposal requests Season 3 funding from the unreleased CELO treasury (July–December 2026) for Stabila to continue coordinating DeFi incentives and liquidity strategy across Celo. The mandate continues to evolve from broad ecosystem bootstrapping toward focused, strategic capital deployment — prioritizing market depth, capital efficiency, and sustainable economic activity.
+
+Season 3 also aligns Stabila's work with the ecosystem's north star metric of monthly chain revenue. DeFi represents a meaningful opportunity to contribute to chain fees: every swap, lending action, and FX conversion is a fee-paying transaction. Stabila's role is to create the conditions that attract DeFi users and volume organically: deep liquidity, functioning venues, and well-integrated assets.
+
+This request complements the Celo Core Co. Season 3 proposal: Celo Core Co drives partnerships, onboarding, and distribution; Stabila builds the market structure those integrations rely on.
+
+## Background
+
+Over the past several seasons, Stabila has deployed targeted liquidity incentives and coordinated with protocol teams and risk curators to build out core components of Celo's DeFi stack: DEX liquidity, lending markets, liquid staking infrastructure, and stablecoin market depth.
+
+Season 2's outcomes are detailed in Stabila's Season 2 retrospective. Highlights include the launch of Morpho on Celo with curated lending markets, the launch of UpDown's leveraged FX trading built on Celo's stable assets, and Celo becoming the leading network for tokenized gold, with XAUt0 integrated as DeFi collateral. Throughout a challenging period for DeFi markets broadly, incentive programs were continually evaluated and adjusted based on performance and liquidity retention.
+
+Season 3 reflects a broader shift in how the ecosystem measures progress. Deep liquidity remains the foundation (fee-generating activity doesn't happen in shallow markets), but the measure of success is what that liquidity enables: organic usage and fees, rather than headline TVL alone, which is sensitive to token prices and can sit idle. The season builds on the infrastructure now in place, with flexibility to back opportunities as they emerge.
+
+## Season 3 Objectives
+
+The focus of Season 3 is to deepen the liquidity and strengthen the market infrastructure that enable organic, fee-generating DeFi activity on Celo in direct support of the ecosystem's Season 3 north star.
+
+## Scope of Work
+
+### 1. Liquidity & Trading Markets
+
+Deepen and sustain the trading venues where onchain activity generates fees: spot, FX, and leveraged markets with emphasis on stablecoins and local-currency pairs at the core of Celo's payments use cases.
+
+Focus areas include:
+
+* Stablecoin and local-currency FX liquidity
+* Blue-chip asset liquidity
+* Yield-bearing assets and liquid staking infrastructure
+* Perpetual and leveraged FX markets
+* Market-making and automated liquidity management
+
+### 2. Lending & Credit Markets
+
+Expand Celo's lending and credit markets and the collateral base behind them, improving capital efficiency and access to onchain credit.
+
+Focus areas include:
+
+* Lending market incentives across Aave and Morpho
+* New collateral onboarding, including yield-bearing assets
+* Curated market expansion
+* Risk management and curator coordination
+
+### 3. Strategic DeFi Integrations
+
+Ensure new assets and partners entering the ecosystem — including those onboarded through Celo Core Co.'s partnership work — launch into liquid, functioning markets.
+
+Focus areas include:
+
+* Stablecoin issuers
+* Yield-bearing and real-world assets
+* Financial infrastructure providers
+* Emerging DeFi protocols
+
+### 4. Ecosystem Operations & Growth
+
+Support the operational work required to execute Stabila's mandate.
+
+Focus areas include:
+
+* Governance execution and legal/administrative support
+* Protocol and counterparty coordination
+* Communications and reporting
+
+Across all categories, incentive allocation is pooled and performance-based, with flexibility to rebalance toward what works and wind down programs that do not demonstrate durable usage.
+
+## Budget Overview
+
+See the budget table in the [forum post](https://forum.celo.org/t/stabila-season-3-funding-proposal/13574).
+
+## Funding Request
+
+Stabila is requesting $360,000 in funding for Season 3, denominated in CELO. The final CELO-denominated amount will be calculated using the 90-day trailing average CELO price at the time of proposal submission.
+
+This request represents a reduction of more than 62% from Stabila's Season 2 funding request in USD terms — reflecting a leaner mandate focused on the most effective components of Celo's DeFi stack. Stewarding community funds responsibly means concentrating capital where it demonstrably works, and this budget reflects that commitment.
+
+Upon approval, funds will be withdrawn and sent to the Stabila multisig wallet.
+
+Unused funds may be returned to the Community Fund or rolled forward, subject to community input and governance approval.
+
+## Timeline
+
+This proposal covers Season 3 (July–December 2026).
+
+* July: Funding received and Season 3 execution begins
+* Q3–Q4: Ongoing liquidity, ecosystem, and partnership initiatives
+* December: Season 3 retrospective shared with the community
+
+As with previous seasons, Stabila intends to publish a retrospective outlining capital deployment, ecosystem outcomes, key learnings, and progress against stated objectives.
+
+## Team & Multi-Sig
+
+Funds will be withdrawn to the Stabila multisig upon governance approval from the unreleased CELO treasury.
+
+Stabila Multi-Sig: 0x9C257bDC314dc516e673728D70F45444F6e22412
+
+**Current Signers:**
+
+* Kevin Tharayil – 0x605C6B7a97748cbd0DE9C8643cdc502AB1DfDEd2
+* Productmatt – 0x1f5979355411dF24c5Ce21Df5bD9f2fff418c194
+* Martin Volpe – 0x0159B8f51fA6eDEF721d6D87002587130CD8246c
+* Michael Kwan – 0x78670759E39E955E55EFA52d6d4BECa86F40b498
+* Kishan Peshwa – 0x80d0A4aF5beff0Ca6127e203981afAB9B6152B60
+
+Proposed Changes
+============================
+
+The proposal releases 4,838,709.68 CELO from the `CeloUnreleasedTreasury` to the Governance contract (the Community Fund) and increases the Stabila multisig's CELO allowance by the same amount, allowing the multisig to withdraw the funds via `transferFrom`.
+
+`CeloUnreleasedTreasury.release` is callable only by the contract registered as `EpochManager` in the Registry, so — following the precedent of [cgp-0207](cgp-0207.md), [cgp-0232](cgp-0232.md), and [cgp-0238](cgp-0238.md) — the Registry entry is temporarily pointed at Governance for the duration of the release and restored immediately afterwards.
+
+`increaseAllowance` is used instead of `approve` so that any CELO the Stabila multisig has not yet withdrawn under its existing (Season 2) allowance is preserved rather than overwritten.
+
+## Transaction Descriptions
+
+1. Temporarily set Governance as `EpochManager` in the Registry
+   - Destination: Registry (0x000000000000000000000000000000000000ce10) — `setAddressFor(string, address)`
+   - Data: `"EpochManager"`, 0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972 (Governance)
+   - Value: 0
+
+2. Release 4,838,709.68 CELO from the unreleased treasury to Governance
+   - Destination: CeloUnreleasedTreasury (0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f) — `release(address, uint256)`
+   - Data: 0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972 (Governance), 4838709680000000000000000 (4,838,709.68 CELO)
+   - Value: 0
+
+3. Restore `EpochManager` in the Registry to the original address
+   - Destination: Registry (0x000000000000000000000000000000000000ce10) — `setAddressFor(string, address)`
+   - Data: `"EpochManager"`, 0xF424B5e85B290b66aC20f8A9EAB75E25a526725E (EpochManager)
+   - Value: 0
+
+4. Increase the Stabila multisig CELO allowance by 4,838,709.68 CELO
+   - Destination: GoldToken (0x471EcE3750Da237f93B8E339c536989b8978a438) — `increaseAllowance(address, uint256)`
+   - Data: 0x9C257bDC314dc516e673728D70F45444F6e22412 (Stabila multisig), 4838709680000000000000000 (4,838,709.68 CELO)
+   - Value: 0
+
+## Json Script
+
+```json
+[
+  {
+    "contract": "Registry",
+    "address": "0x000000000000000000000000000000000000ce10",
+    "function": "setAddressFor",
+    "args": ["EpochManager", "0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972"],
+    "value": "0",
+    "description": "Temporarily set Governance as EpochManager in Registry"
+  },
+  {
+    "contract": "CeloUnreleasedTreasury",
+    "address": "0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f",
+    "function": "release",
+    "args": [
+      "0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972",
+      "4838709680000000000000000"
+    ],
+    "value": "0",
+    "description": "Release 4,838,709.68 CELO from the unreleased treasury to Governance (Community Fund)"
+  },
+  {
+    "contract": "Registry",
+    "address": "0x000000000000000000000000000000000000ce10",
+    "function": "setAddressFor",
+    "args": ["EpochManager", "0xF424B5e85B290b66aC20f8A9EAB75E25a526725E"],
+    "value": "0",
+    "description": "Restore EpochManager in Registry to original address"
+  },
+  {
+    "contract": "GoldToken",
+    "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+    "function": "increaseAllowance",
+    "args": [
+      "0x9C257bDC314dc516e673728D70F45444F6e22412",
+      "4838709680000000000000000"
+    ],
+    "value": "0",
+    "description": "Increase the Stabila multisig CELO allowance by 4,838,709.68"
+  }
+]
+```
+
+Verification
+============================
+
+Once the proposal is submitted on-chain, a human readable version can be inspected with:
+
+`$ celocli governance:show --proposalID <ID> --node https://forno.celo.org`
+
+Voters can verify that:
+
+1. Transactions 1 and 3 call the Registry (0x000000000000000000000000000000000000ce10) and only touch the `EpochManager` entry — transaction 3 restores it to the current on-chain value (0xF424B5e85B290b66aC20f8A9EAB75E25a526725E, verifiable via `celocli network:contracts` or `Registry.getAddressForString("EpochManager")`).
+2. Transaction 2 calls `release` on the CeloUnreleasedTreasury proxy (0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f, verifiable via `Registry.getAddressForString("CeloUnreleasedTreasury")`) with the Governance contract (0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972) as recipient — funds move from the unreleased treasury into the Community Fund, not to any external party.
+3. Transaction 4 calls `increaseAllowance` on the CELO token (0x471EcE3750Da237f93B8E339c536989b8978a438) for the Stabila multisig (0x9C257bDC314dc516e673728D70F45444F6e22412) — the same multisig that received the Season 2 allowance in [cgp-0222](cgp-0222.md).
+4. 4838709680000000000000000 wei = 4,838,709.68 CELO ≈ $360,000 at the 90-day trailing average CELO price of $0.0744 (April 24–July 22, 2026).
+
+Risks
+============================
+
+This proposal does not deploy or upgrade contracts and does not permanently change network parameters, so it represents minimal risk to the network.
+
+* The `EpochManager` Registry entry is modified and restored within the same atomic proposal execution; no intermediate state is observable by other transactions.
+* The proposal does not transfer funds directly to an external address. It releases CELO into the Community Fund and grants an allowance, which means the funds are not lost if the allowance address were wrong — and the allowance recipient is the same Stabila multisig already used in Season 2.
+* Using `increaseAllowance` (rather than `approve`) preserves any remaining Season 2 allowance.
+
+Useful Links
+============================
+
+* [Forum post: Stabila Season 3 Funding Proposal](https://forum.celo.org/t/stabila-season-3-funding-proposal/13574)
+* [Stabila Season 2 Funding Request (cgp-0222)](cgp-0222.md)

--- a/CGPs/cgp-0246/mainnet.json
+++ b/CGPs/cgp-0246/mainnet.json
@@ -1,0 +1,40 @@
+[
+  {
+    "contract": "Registry",
+    "address": "0x000000000000000000000000000000000000ce10",
+    "function": "setAddressFor",
+    "args": ["EpochManager", "0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972"],
+    "value": "0",
+    "description": "Temporarily set Governance as EpochManager in Registry"
+  },
+  {
+    "contract": "CeloUnreleasedTreasury",
+    "address": "0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f",
+    "function": "release",
+    "args": [
+      "0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972",
+      "4838709680000000000000000"
+    ],
+    "value": "0",
+    "description": "Release 4,838,709.68 CELO from the unreleased treasury to Governance (Community Fund)"
+  },
+  {
+    "contract": "Registry",
+    "address": "0x000000000000000000000000000000000000ce10",
+    "function": "setAddressFor",
+    "args": ["EpochManager", "0xF424B5e85B290b66aC20f8A9EAB75E25a526725E"],
+    "value": "0",
+    "description": "Restore EpochManager in Registry to original address"
+  },
+  {
+    "contract": "GoldToken",
+    "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+    "function": "increaseAllowance",
+    "args": [
+      "0x9C257bDC314dc516e673728D70F45444F6e22412",
+      "4838709680000000000000000"
+    ],
+    "value": "0",
+    "description": "Increase the Stabila multisig CELO allowance by 4,838,709.68"
+  }
+]


### PR DESCRIPTION
## Summary

Adds CGP-0246 — Stabila Season 3 funding request: **$360,000 USD as 4,838,709.68 CELO** (90-day trailing average price of $0.0744) from the unreleased CELO treasury to the Stabila multisig, per the [forum proposal](https://forum.celo.org/t/stabila-season-3-funding-proposal/13574).

## Transactions

`CeloUnreleasedTreasury.release` is callable only by the registered `EpochManager`, so the Registry entry is temporarily pointed at Governance and restored, following the precedent of cgp-0207, cgp-0232, and cgp-0238:

1. `Registry.setAddressFor("EpochManager", Governance)` — temporary
2. `CeloUnreleasedTreasury.release(Governance, 4838709680000000000000000)` — releases 4,838,709.68 CELO into the Community Fund
3. `Registry.setAddressFor("EpochManager", 0xF424B5e85B290b66aC20f8A9EAB75E25a526725E)` — restore
4. `GoldToken.increaseAllowance(0x9C257bDC314dc516e673728D70F45444F6e22412, 4838709680000000000000000)` — Stabila multisig allowance

`increaseAllowance` (rather than `approve`) is used so any allowance remaining from Season 2 would be preserved rather than overwritten. (As of authoring, the Season 2 allowance from cgp-0222 is fully withdrawn — current allowance is 0.)

## Verification performed

- Multisig address and signer list match the forum post and the Season 2 recipient in cgp-0222.
- Price cross-checked against CoinGecko: 90-day average $0.0741, spot $0.0711 — $360,000 / $0.0744 = 4,838,709.68 CELO.
- Registry entries (`EpochManager`, `CeloUnreleasedTreasury`, `Governance`, `GoldToken`) verified against current mainnet state.

## Test plan

- [x] Anvil fork of Celo mainnet (block 72975791): executed all 4 transactions from `mainnet.json` impersonating Governance
- [x] Negative test: `release` reverts while `EpochManager` still points at the real EpochManager
- [x] `Transfer(treasury -> Governance, 4838709680000000000000000)` and `Released` events emitted
- [x] `EpochManager` Registry entry restored to `0xF424...725E` after execution
- [x] Stabila multisig allowance increased by exactly 4,838,709.68 CELO
- [x] Multisig withdrawal via `transferFrom` succeeds for the full amount; allowance returns to pre-proposal level

Note: native CELO balance movement happens in the transfer precompile (`0x...fd`), which vanilla anvil does not implement (silent no-op locally); the fork test asserts the emitted events and allowance storage, which pin down calldata, authorization, and accounting.