### PR TITLE
cgp-0247: Celo Core Co. Season 3 Funding Proposal

### DIFF
--- a/CGPs/cgp-0247.md
+++ b/CGPs/cgp-0247.md
@@ -1,0 +1,252 @@
+---
+cgp: 247
+title: Celo Core Co. Season 3 Funding Proposal
+date-created: 2026-07-24
+author: '@CeloCoreCo'
+status: DRAFT
+discussions-to: https://forum.celo.org/t/celo-core-co-season-3-funding-proposal/13565
+governance-proposal-id:
+date-executed:
+---
+
+Proposal Description
+============================
+
+## Proposal Key Aspects
+
+* **Receiver Entity:** Celo Governance
+* **Status:** [DRAFT]
+* **Author(s):** @CeloCoreCo
+* **Type of Request:** Funding
+* **Funding Request:** $2,396,000 USD equivalent to 31,609,499 CELO (CELO-denominated at the 90-day trailing average CELO price of $0.0758 — April 15–July 13, 2026)
+
+## Summary
+
+This proposal requests funding from the unreleased CELO treasury to support the next six months of work by Celo Core Co., the newly unified core contributor organization formed through the alignment of cLabs and the Celo Foundation.
+
+Season 3 marks an important milestone in Celo's evolution. Earlier this year, cLabs and the Celo Foundation merged into Celo Core Co., bringing together protocol development, ecosystem growth, partnerships, communications, operations, and execution under a single organization. This structure is designed to improve coordination, increase execution velocity, and ensure that protocol development and ecosystem growth remain closely aligned around shared objectives.
+
+The requested funding supports two primary areas of work:
+
+* **Engineering and Product Development:** advancing Celo's protocol roadmap, infrastructure, security, scalability, and ecosystem-critical products.
+* **Ecosystem Growth and Adoption:** supporting strategic partnerships, builder growth, ecosystem development, communications, and market expansion.
+
+This proposal covers the period from July through December 2026 and continues the community funding model established in previous seasons, with milestone-based reporting and accountability.
+
+## Background
+
+The first half of 2026 represented a significant transition period for the Celo ecosystem.
+
+During this period, cLabs successfully delivered major protocol milestones including the Jovian hardfork, continued progress toward Espresso integration, improvements to network performance and security, and ongoing stewardship of ecosystem-critical infrastructure.
+
+At the same time, the Celo Foundation continued supporting ecosystem growth through strategic partnerships, builder programs, MiniPay ecosystem expansion, industry engagement, and marketing and communications efforts that helped maintain Celo's position as one of the most actively used Ethereum Layer 2 ecosystems. To read more about the progress made over Season 2, please visit the cLabs and Celo Foundation retrospectives.
+
+Recognizing the increasing importance of coordination between protocol development and ecosystem growth, cLabs and the Celo Foundation aligned operations under a single organization, Celo Core Co.
+
+Season 3 represents the first funding cycle under this new operating model.
+
+## Season 3 North Star and Objectives
+
+**North Star: Increase number of users and make it easier and cheaper to bring money onchain**
+
+The focus of Season 3 is to grow real, organic usage of Celo and make bringing money onchain easier and cheaper, advancing our position as the leading blockchain ecosystem for real-world adoption while strengthening the foundations for long-term ecosystem sustainability. The way we will collectively work towards this north star breaks down into the following protocol and ecosystem objectives:
+
+**Protocol & Product Objectives**
+
+* Deliver the H2 2026 engineering roadmap
+* Continue Ethereum alignment and interoperability efforts
+* Advance ecosystem-critical infrastructure and tooling
+* Support key user-facing products (Valora) and developer experiences
+
+**Ecosystem Objectives**
+
+* Expand strategic partnerships and distribution channels
+* Grow agentic activity, infrastructure and ecosystem
+* Accelerate MiniPay and mini app adoption
+* Support stablecoin growth for onchain FX use cases
+* Advance initiatives that strengthen sustainable onchain economic activity
+* Improve ecosystem coordination, communications, and visibility
+
+## Key Metric: Monthly Chain Revenue (Gross Fees)
+
+Season 3 adopts monthly chain revenue (gross fees) as our north star metric. Unlike transaction counts or TVL, chain revenue can't be inflated by incentives or wash activity — someone has to find Celo useful enough to pay for it. It also captures quality of usage rather than volume, is less exposed to market conditions, and ties directly to long-term network sustainability: as fees grow, so does the value flowing back to the protocol and its community.
+
+Importantly, this growth does not come at users' expense: the median cost per transaction on Celo remains sub-cent, so revenue scales with usage, not with what any individual user pays.
+
+We've already shown this metric can move fast. Over the past season, monthly chain revenue has grown roughly 10x, to ~$125,000 per month on average, driven by increased minimum base fees, MiniPay growth, stablecoin activity, and rising organic transaction demand. Season 3 is about proving that growth compounds sustainably through payment partner onboarding, local fiat-backed stablecoins, agentic use cases, and continued MiniPay expansion, rather than one-off spikes.
+
+Chain revenue also drives value accrual to CELO directly: as fees grow, so does the CELO purchased through the protocol's fee mechanism, aligning network usage with the long-term interests of CELO holders, a core focus of the ongoing Tokenomics Initiative.
+
+## Engineering & Product Roadmap
+
+The second half of the year is focused on big protocol upgrades, higher throughput, tighter security, better infrastructure, and research that shapes what comes next. As always, sequencing may shift as dependencies get finalized.
+
+You can read more about the milestones and planned protocol and product development work for the second half of 2026 in the H2 Engineering Roadmap.
+
+### Engineering Budget
+
+| Cost Category | Details | Total Cost (USD) |
+| --- | --- | --- |
+| Fully Loaded Engineering Costs | Core protocol engineering, DevOps, security, product, infrastructure and tooling contributors | 838,000 |
+| Infrastructure & Tooling | Cloud services, monitoring, testing, analytics, developer infrastructure | 197,000 |
+| **Total** | | **1,035,000** |
+
+## Ecosystem Growth & Adoption
+
+The ecosystem portion of this proposal supports the programs, partnerships, and growth initiatives required to continue expanding Celo adoption globally.
+
+1. **Adoption & Strategic Initiatives** — Estimated Budget: 356,000. Supports ecosystem partnerships, commercial relationships, distribution channels, and integrations that expand Celo's reach and utility. This category includes work across stablecoins, payments, financial infrastructure, MiniPay ecosystem expansion, and other strategic initiatives that can drive meaningful ecosystem adoption.
+
+2. **Builder & Ecosystem Growth** — Estimated Budget: 490,000. Supports developer onboarding, ecosystem support, builder activation, mini app growth, educational initiatives, AI infrastructure and agentic programs that help cement Celo's reputation as the leading Ethereum L2 for DAUs, and supporting builders from experimentation through production and deployment.
+
+3. **Marketing & Communications** — Estimated Budget: 285,000. Supports ecosystem storytelling, media relations, launch coordination, educational content, community communications, and broader awareness efforts that strengthen Celo's position within the industry.
+
+4. **Events & Strategic Ecosystem Presence** — Estimated Budget: 130,000. Maintains a focused presence at high-impact industry and developer events aligned with strategic partnerships, ecosystem growth, and business development objectives.
+
+5. **Regional Ecosystem Growth** — Estimated Budget: 100,000. Supports regional ecosystem initiatives and contributors that extend Celo's reach into key markets while maintaining coordination with global ecosystem priorities.
+
+### Ecosystem Budget
+
+| Category | Budget (USD) |
+| --- | --- |
+| Adoption & Strategic Initiatives | 356,000 |
+| Builder & Ecosystem Growth | 490,000 |
+| Marketing & Communications | 285,000 |
+| Events & Strategic Ecosystem Presence | 130,000 |
+| Regional Ecosystem Growth | 100,000 |
+| **Total** | **1,361,000** |
+
+## Funding Request
+
+Celo Core Co. is requesting $2,396,000 in funding for Season 3.
+
+The requested budget combines the protocol development scope historically supported through cLabs funding proposals and the ecosystem growth scope historically supported through Celo Foundation funding proposals.
+
+Final CELO-denominated amounts will be calculated using the 90 day trailing average CELO price at the time of proposal submission, consistent with previous funding proposals.
+
+Unused funds will be returned to the Community Fund or rolled forward subject to community governance approval.
+
+This request represents a cumulative reduction of more than 12.6% from Season 2's combined funding across cLabs and the Celo Foundation. The unification into Celo Core Co. allowed us to streamline operations and reduce overhead, and we've made deliberate, and at times difficult, decisions to run a leaner organization. We believe stewarding community funds responsibly means doing more with less, and this budget reflects that commitment while preserving full capacity to deliver on the Season 3 roadmap.
+
+## Timeline
+
+This proposal covers Season 3 (July–December 2026).
+
+* July: Proposal submission and governance vote; funding received upon approval
+* Q3–Q4: Ongoing program execution across builder growth, ecosystem support, and strategic presence
+* December: Season 3 retrospective shared with the community
+
+As with Season 1 and 2, Celo Core Co. will publish a Season 3 retrospective outlining outcomes, learnings, and measurable impact.
+
+## Team & Multisig
+
+Funds will be withdrawn to a Celo Core Co. controlled multisig upon approval from the unreleased CELO treasury.
+
+Celo Core Co. Multisig: 0xB0D0780eDDC2FA35906C0b37B9b4Dc7583C3DbB0
+
+The multisig is a Gnosis Safe on Celo mainnet with a 3-of-5 signer threshold.
+
+Proposed Changes
+============================
+
+The proposal releases 31,609,499 CELO from the `CeloUnreleasedTreasury` to the Governance contract (the Community Fund) and increases the Celo Core Co. multisig's CELO allowance by the same amount, allowing the multisig to withdraw the funds via `transferFrom`.
+
+`CeloUnreleasedTreasury.release` is callable only by the contract registered as `EpochManager` in the Registry, so — following the precedent of [cgp-0207](cgp-0207.md), [cgp-0232](cgp-0232.md), [cgp-0238](cgp-0238.md), and [cgp-0246](cgp-0246.md) — the Registry entry is temporarily pointed at Governance for the duration of the release and restored immediately afterwards.
+
+`increaseAllowance` is used instead of `approve` so that any pre-existing CELO allowance to the multisig is preserved rather than overwritten (as of authoring, that allowance is 0).
+
+## Transaction Descriptions
+
+1. Temporarily set Governance as `EpochManager` in the Registry
+   - Destination: Registry (0x000000000000000000000000000000000000ce10) — `setAddressFor(string, address)`
+   - Data: `"EpochManager"`, 0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972 (Governance)
+   - Value: 0
+
+2. Release 31,609,499 CELO from the unreleased treasury to Governance
+   - Destination: CeloUnreleasedTreasury (0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f) — `release(address, uint256)`
+   - Data: 0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972 (Governance), 31609499000000000000000000 (31,609,499 CELO)
+   - Value: 0
+
+3. Restore `EpochManager` in the Registry to the original address
+   - Destination: Registry (0x000000000000000000000000000000000000ce10) — `setAddressFor(string, address)`
+   - Data: `"EpochManager"`, 0xF424B5e85B290b66aC20f8A9EAB75E25a526725E (EpochManager)
+   - Value: 0
+
+4. Increase the Celo Core Co. multisig CELO allowance by 31,609,499 CELO
+   - Destination: GoldToken (0x471EcE3750Da237f93B8E339c536989b8978a438) — `increaseAllowance(address, uint256)`
+   - Data: 0xB0D0780eDDC2FA35906C0b37B9b4Dc7583C3DbB0 (Celo Core Co. multisig), 31609499000000000000000000 (31,609,499 CELO)
+   - Value: 0
+
+## Json Script
+
+```json
+[
+  {
+    "contract": "Registry",
+    "address": "0x000000000000000000000000000000000000ce10",
+    "function": "setAddressFor",
+    "args": ["EpochManager", "0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972"],
+    "value": "0",
+    "description": "Temporarily set Governance as EpochManager in Registry"
+  },
+  {
+    "contract": "CeloUnreleasedTreasury",
+    "address": "0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f",
+    "function": "release",
+    "args": [
+      "0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972",
+      "31609499000000000000000000"
+    ],
+    "value": "0",
+    "description": "Release 31,609,499 CELO from the unreleased treasury to Governance (Community Fund)"
+  },
+  {
+    "contract": "Registry",
+    "address": "0x000000000000000000000000000000000000ce10",
+    "function": "setAddressFor",
+    "args": ["EpochManager", "0xF424B5e85B290b66aC20f8A9EAB75E25a526725E"],
+    "value": "0",
+    "description": "Restore EpochManager in Registry to original address"
+  },
+  {
+    "contract": "GoldToken",
+    "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+    "function": "increaseAllowance",
+    "args": [
+      "0xB0D0780eDDC2FA35906C0b37B9b4Dc7583C3DbB0",
+      "31609499000000000000000000"
+    ],
+    "value": "0",
+    "description": "Increase the Celo Core Co multisig CELO allowance by 31,609,499"
+  }
+]
+```
+
+Verification
+============================
+
+Once the proposal is submitted on-chain, a human readable version can be inspected with:
+
+`$ celocli governance:show --proposalID <ID> --node https://forno.celo.org`
+
+Voters can verify that:
+
+1. Transactions 1 and 3 call the Registry (0x000000000000000000000000000000000000ce10) and only touch the `EpochManager` entry — transaction 3 restores it to the current on-chain value (0xF424B5e85B290b66aC20f8A9EAB75E25a526725E, verifiable via `Registry.getAddressForString("EpochManager")`).
+2. Transaction 2 calls `release` on the CeloUnreleasedTreasury proxy (0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f, verifiable via `Registry.getAddressForString("CeloUnreleasedTreasury")`) with the Governance contract (0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972) as recipient — funds move from the unreleased treasury into the Community Fund, not to any external party.
+3. Transaction 4 calls `increaseAllowance` on the CELO token (0x471EcE3750Da237f93B8E339c536989b8978a438) for the Celo Core Co. multisig (0xB0D0780eDDC2FA35906C0b37B9b4Dc7583C3DbB0) — a 3-of-5 Gnosis Safe on Celo mainnet, matching the address published in the forum post.
+4. 31609499000000000000000000 wei = 31,609,499 CELO ≈ $2,396,000 at the 90-day trailing average CELO price of $0.0758 (April 15–July 13, 2026).
+
+Risks
+============================
+
+This proposal does not deploy or upgrade contracts and does not permanently change network parameters, so it represents minimal risk to the network.
+
+* The `EpochManager` Registry entry is modified and restored within the same atomic proposal execution; no intermediate state is observable by other transactions.
+* The proposal does not transfer funds directly to an external address. It releases CELO into the Community Fund and grants an allowance, which means the funds are not lost if the allowance address were wrong.
+* Using `increaseAllowance` (rather than `approve`) preserves any pre-existing allowance.
+
+Useful Links
+============================
+
+* [Forum post: Celo Core Co. Season 3 Funding Proposal](https://forum.celo.org/t/celo-core-co-season-3-funding-proposal/13565)
+* [Stabila Season 3 Funding Proposal (cgp-0246)](cgp-0246.md)

--- a/CGPs/cgp-0247/mainnet.json
+++ b/CGPs/cgp-0247/mainnet.json
@@ -1,0 +1,40 @@
+[
+  {
+    "contract": "Registry",
+    "address": "0x000000000000000000000000000000000000ce10",
+    "function": "setAddressFor",
+    "args": ["EpochManager", "0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972"],
+    "value": "0",
+    "description": "Temporarily set Governance as EpochManager in Registry"
+  },
+  {
+    "contract": "CeloUnreleasedTreasury",
+    "address": "0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f",
+    "function": "release",
+    "args": [
+      "0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972",
+      "31609499000000000000000000"
+    ],
+    "value": "0",
+    "description": "Release 31,609,499 CELO from the unreleased treasury to Governance (Community Fund)"
+  },
+  {
+    "contract": "Registry",
+    "address": "0x000000000000000000000000000000000000ce10",
+    "function": "setAddressFor",
+    "args": ["EpochManager", "0xF424B5e85B290b66aC20f8A9EAB75E25a526725E"],
+    "value": "0",
+    "description": "Restore EpochManager in Registry to original address"
+  },
+  {
+    "contract": "GoldToken",
+    "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+    "function": "increaseAllowance",
+    "args": [
+      "0xB0D0780eDDC2FA35906C0b37B9b4Dc7583C3DbB0",
+      "31609499000000000000000000"
+    ],
+    "value": "0",
+    "description": "Increase the Celo Core Co multisig CELO allowance by 31,609,499"
+  }
+]


### PR DESCRIPTION
## Summary

Adds CGP-0247 — Celo Core Co. Season 3 funding request: **$2,396,000 USD as 31,609,499 CELO** (90-day trailing average price of $0.0758, April 15–July 13, 2026) from the unreleased CELO treasury to the Celo Core Co. multisig, per the [forum proposal](https://forum.celo.org/t/celo-core-co-season-3-funding-proposal/13565).

## Transactions

Same structure as cgp-0246 (#824): `CeloUnreleasedTreasury.release` is callable only by the registered `EpochManager`, so the Registry entry is temporarily pointed at Governance and restored, following the precedent of cgp-0207, cgp-0232, and cgp-0238:

1. `Registry.setAddressFor("EpochManager", Governance)` — temporary
2. `CeloUnreleasedTreasury.release(Governance, 31609499000000000000000000)` — releases 31,609,499 CELO into the Community Fund
3. `Registry.setAddressFor("EpochManager", 0xF424B5e85B290b66aC20f8A9EAB75E25a526725E)` — restore
4. `GoldToken.increaseAllowance(0xB0D0780eDDC2FA35906C0b37B9b4Dc7583C3DbB0, 31609499000000000000000000)` — Celo Core Co. multisig allowance

`increaseAllowance` (rather than `approve`) is used so any pre-existing allowance would be preserved. As of authoring, the Governance → multisig allowance is 0.

## Verification performed

- Multisig address matches the forum post. On-chain it is a live Gnosis Safe on Celo mainnet with a 3-of-5 signer threshold, seeded with 1 CELO. Note: unlike the Stabila proposal, no signer list is published in the forum post — reviewers may want Celo Core Co. to publish the five signer identities for the record.
- Price cross-checked against CoinGecko for the stated window (April 15 – July 13, 2026): average $0.0760 vs the claimed $0.0758. $2,396,000 / $0.0758 = 31,609,498.68 → 31,609,499 CELO.
- Registry entries (`EpochManager`, `CeloUnreleasedTreasury`, `Governance`, `GoldToken`) verified against current mainnet state.
- Treasury balance (≈125.6M CELO) covers the release.

## Test plan

- [x] Anvil fork of Celo mainnet (block 72996240): executed all 4 transactions from `mainnet.json` impersonating Governance
- [x] Negative test: `release` reverts while `EpochManager` still points at the real EpochManager
- [x] `Transfer(treasury -> Governance, 31609499000000000000000000)` and `Released` events emitted
- [x] `EpochManager` Registry entry restored to `0xF424...725E` after execution
- [x] Celo Core Co. multisig allowance increased by exactly 31,609,499 CELO
- [x] Multisig withdrawal via `transferFrom` succeeds for the full amount; allowance returns to pre-proposal level

Note: native CELO balance movement happens in the transfer precompile (`0x...fd`), which vanilla anvil does not implement (silent no-op locally); the fork test asserts the emitted events and allowance storage, which pin down calldata, authorization, and accounting.