### PR TITLE
cgp-0248: CICLOPS Season 3 Funding Proposal

### DIFF
--- a/CGPs/cgp-0248.md
+++ b/CGPs/cgp-0248.md
@@ -1,0 +1,219 @@
+---
+cgp: 248
+title: CICLOPS Season 3 Funding Proposal
+date-created: 2026-07-30
+author: '@KishanP'
+status: DRAFT
+discussions-to: TODO-forum-link
+governance-proposal-id:
+date-executed:
+---
+
+Proposal Description
+============================
+
+## Proposal Key Aspects
+
+* **Receiver Entity:** Celo Governance
+* **Status:** [DRAFT]
+* **Author(s):** @KishanP
+* **Type of Request:** Funding
+* **Funding Request:** $2,670,000 USD equivalent to 35,838,926 CELO (CELO-denominated at the 90-day trailing average CELO price of $0.0745 — April 23–July 21, 2026)
+
+## Summary
+
+This proposal requests funding from the Unreleased Celo Treasury to support CICLOPS during Season 3 (July–December 2026).
+
+Since its inception, CICLOPS has served as Celo's infrastructure coordination and stewardship mechanism, ensuring that critical ecosystem infrastructure remains operational, adequately resourced, and aligned with the evolving needs of the network.
+
+As Celo continues to mature as an Ethereum Layer 2 and prepares for the next phase of protocol and ecosystem growth, infrastructure remains a foundational dependency. Explorers, indexers, wallet infrastructure, data availability providers, monitoring systems, bridges, exchanges, RPC providers, and other ecosystem services all play a critical role in maintaining network reliability and supporting builders, users, and partners.
+
+This proposal requests continued funding to support the infrastructure required for Celo's ongoing operation and future roadmap execution. As in previous seasons, all funds will be used exclusively for infrastructure and vendor-related expenses. CICLOPS contributors will continue serving in an oversight and coordination capacity without compensation.
+
+## Background
+
+CICLOPS was established to provide sustainable coordination, funding, and oversight of ecosystem-critical infrastructure.
+
+Over the past several seasons, CICLOPS has helped ensure the successful operation of key infrastructure providers across the Celo ecosystem while supporting major protocol upgrades, ecosystem expansion, and increasing network usage.
+
+As Celo grows, the infrastructure layer supporting the network continues to expand in both complexity and importance. Protocol upgrades, new applications, growing stablecoin activity, increased institutional participation, and broader ecosystem adoption all place additional demands on infrastructure providers and service operators.
+
+Season 3 continues this work by ensuring that critical infrastructure remains reliable, resilient, and prepared to support upcoming protocol and ecosystem initiatives.
+
+## Alignment with the Celo Core Co. Roadmap
+
+Season 3 of CICLOPS is designed to support the successful execution of the Celo Core Co. roadmap and broader ecosystem priorities.
+
+While Celo Core Co. is responsible for protocol development, product innovation, and ecosystem growth, CICLOPS ensures that the infrastructure layer required to support those initiatives remains operational and adequately resourced.
+
+Upcoming protocol upgrades, performance improvements, ecosystem integrations, and adoption initiatives will continue to rely on a broad set of infrastructure providers and service partners. CICLOPS exists to ensure that these dependencies do not become bottlenecks to execution.
+
+## Scope of This Proposal
+
+This Season 3 funding request covers July–December 2026 and supports:
+
+* Renewals and maintenance of existing infrastructure providers
+* Infrastructure upgrades required to support protocol evolution
+* Expansion of infrastructure capacity where necessary
+* Support for emerging ecosystem infrastructure requirements
+* Strategic flexibility to address urgent or unforeseen infrastructure needs
+
+As in prior seasons, CICLOPS contributors will not receive compensation through this proposal. All funds will be directed toward infrastructure providers and related operational expenses.
+
+## Infrastructure Focus Areas
+
+The following categories represent the primary infrastructure areas expected to be supported during Season 3.
+
+| Infrastructure Category | Description |
+| --- | --- |
+| Wallet Support, Account Abstraction & Infrastructure | Ensures secure user interactions, supports growing MiniPay adoption, and maintains critical wallet tooling such as Valora. |
+| Oracles & Indexers | Provide reliable data access and integrity for applications, developers, and ecosystem tooling. |
+| Data Availability Infrastructure | Supports scalability, cost efficiency, and verifiability as the network evolves. |
+| Explorers, Monitoring & Transparency | Maintains blockchain explorers, monitoring systems, and public dashboards essential for trust and observability. |
+| Strategic Infrastructure Buffer | Provides flexibility to respond quickly to unforeseen needs, incidents, upgrades, or emerging technologies. |
+
+## Funding Request
+
+CICLOPS is requesting $2,670,000 in funding for Season 3.
+
+The final CELO-denominated amount will be calculated using the 90-day trailing average CELO price at the time of proposal submission.
+
+Funds will be held and disbursed by the CICLOPS multisig and deployed throughout the season based on infrastructure needs, vendor agreements, and ecosystem priorities.
+
+Allocation decisions will continue to be based on infrastructure criticality, operational requirements, and alignment with Celo's roadmap.
+
+## Transparency & Accountability
+
+CICLOPS remains committed to responsible stewardship of ecosystem resources and transparent reporting.
+
+Consistent with previous proposals, CICLOPS commits to publishing an end of year retrospective.
+
+## Timeline
+
+This proposal covers Season 3 (July–December 2026).
+
+* July: Funding received and infrastructure renewals executed
+* Q3–Q4: Ongoing infrastructure support, upgrades, and coordination
+* December: Season 3 retrospective shared with the community
+
+## Multisig
+
+Address for the 3 of 6 CICLOPS Multisig: 0xd71efa410B6EaAB0bAc3b515B393C886BE70F09E
+
+**Signers:**
+
+| Name | Address |
+| --- | --- |
+| Silas Boyd-Wichizer | 0x738D3e9A97D2E2aE6F404D381570E1fb112176BA |
+| Martin Volpe | 0x1a96E07fa5A4801b4881C2DC7B953D7356e26495 |
+| Eric Nakagawa | 0x9AD631ff4518d4a2a7276D2dF0803F37EfA52080 |
+| Anna Tudhope | 0x882774aEE2791e08a0EB04A7BA37c1c5185A6964 |
+| Nauman Mustafa | 0x0798934707B8Ab7ab4CF086D54FC92746B171a13 |
+| Kishan Peshwa | 0x9CD9dC9ec3bC898a374a93421C4b6C0d5bdC9F8d |
+
+Proposed Changes
+============================
+
+The proposal releases 35,838,926 CELO from the `CeloUnreleasedTreasury` to the Governance contract (the Community Fund) and increases the CICLOPS multisig's CELO allowance by the same amount, allowing the multisig to withdraw the funds via `transferFrom`.
+
+`CeloUnreleasedTreasury.release` is callable only by the contract registered as `EpochManager` in the Registry, so — following the precedent of [cgp-0207](cgp-0207.md), [cgp-0232](cgp-0232.md), and [cgp-0238](cgp-0238.md) — the Registry entry is temporarily pointed at Governance for the duration of the release and restored immediately afterwards.
+
+`increaseAllowance` is used instead of `approve` so that any CELO the CICLOPS multisig has not yet withdrawn under its existing (Season 2) allowance is preserved rather than overwritten.
+
+## Transaction Descriptions
+
+1. Temporarily set Governance as `EpochManager` in the Registry
+   - Destination: Registry (0x000000000000000000000000000000000000ce10) — `setAddressFor(string, address)`
+   - Data: `"EpochManager"`, 0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972 (Governance)
+   - Value: 0
+
+2. Release 35,838,926 CELO from the unreleased treasury to Governance
+   - Destination: CeloUnreleasedTreasury (0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f) — `release(address, uint256)`
+   - Data: 0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972 (Governance), 35838926000000000000000000 (35,838,926 CELO)
+   - Value: 0
+
+3. Restore `EpochManager` in the Registry to the original address
+   - Destination: Registry (0x000000000000000000000000000000000000ce10) — `setAddressFor(string, address)`
+   - Data: `"EpochManager"`, 0xF424B5e85B290b66aC20f8A9EAB75E25a526725E (EpochManager)
+   - Value: 0
+
+4. Increase the CICLOPS multisig CELO allowance by 35,838,926 CELO
+   - Destination: GoldToken (0x471EcE3750Da237f93B8E339c536989b8978a438) — `increaseAllowance(address, uint256)`
+   - Data: 0xd71efa410B6EaAB0bAc3b515B393C886BE70F09E (CICLOPS multisig), 35838926000000000000000000 (35,838,926 CELO)
+   - Value: 0
+
+## Json Script
+
+```json
+[
+  {
+    "contract": "Registry",
+    "address": "0x000000000000000000000000000000000000ce10",
+    "function": "setAddressFor",
+    "args": ["EpochManager", "0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972"],
+    "value": "0",
+    "description": "Temporarily set Governance as EpochManager in Registry"
+  },
+  {
+    "contract": "CeloUnreleasedTreasury",
+    "address": "0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f",
+    "function": "release",
+    "args": [
+      "0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972",
+      "35838926000000000000000000"
+    ],
+    "value": "0",
+    "description": "Release 35,838,926 CELO from the unreleased treasury to Governance (Community Fund)"
+  },
+  {
+    "contract": "Registry",
+    "address": "0x000000000000000000000000000000000000ce10",
+    "function": "setAddressFor",
+    "args": ["EpochManager", "0xF424B5e85B290b66aC20f8A9EAB75E25a526725E"],
+    "value": "0",
+    "description": "Restore EpochManager in Registry to original address"
+  },
+  {
+    "contract": "GoldToken",
+    "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+    "function": "increaseAllowance",
+    "args": [
+      "0xd71efa410B6EaAB0bAc3b515B393C886BE70F09E",
+      "35838926000000000000000000"
+    ],
+    "value": "0",
+    "description": "Increase the CICLOPS multisig CELO allowance by 35,838,926"
+  }
+]
+```
+
+Verification
+============================
+
+Once the proposal is submitted on-chain, a human readable version can be inspected with:
+
+`$ celocli governance:show --proposalID <ID> --node https://forno.celo.org`
+
+Voters can verify that:
+
+1. Transactions 1 and 3 call the Registry (0x000000000000000000000000000000000000ce10) and only touch the `EpochManager` entry — transaction 3 restores it to the current on-chain value (0xF424B5e85B290b66aC20f8A9EAB75E25a526725E, verifiable via `celocli network:contracts` or `Registry.getAddressForString("EpochManager")`).
+2. Transaction 2 calls `release` on the CeloUnreleasedTreasury proxy (0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f, verifiable via `Registry.getAddressForString("CeloUnreleasedTreasury")`) with the Governance contract (0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972) as recipient — funds move from the unreleased treasury into the Community Fund, not to any external party.
+3. Transaction 4 calls `increaseAllowance` on the CELO token (0x471EcE3750Da237f93B8E339c536989b8978a438) for the CICLOPS multisig (0xd71efa410B6EaAB0bAc3b515B393C886BE70F09E) — the same multisig established in [cgp-0158](cgp-0158.md) and used for the Season 2 allowance in [cgp-0231](cgp-0231.md) and [cgp-0237](cgp-0237.md).
+4. 35838926000000000000000000 wei = 35,838,926 CELO ≈ $2,670,000 at the 90-day trailing average CELO price of $0.0745 (April 23–July 21, 2026).
+
+Risks
+============================
+
+This proposal does not deploy or upgrade contracts and does not permanently change network parameters, so it represents minimal risk to the network.
+
+* The `EpochManager` Registry entry is modified and restored within the same atomic proposal execution; no intermediate state is observable by other transactions.
+* The proposal does not transfer funds directly to an external address. It releases CELO into the Community Fund and grants an allowance, which means the funds are not lost if the allowance address were wrong — and the allowance recipient is the same CICLOPS multisig already used in previous seasons.
+* Using `increaseAllowance` (rather than `approve`) preserves any remaining Season 2 allowance.
+
+Useful Links
+============================
+
+* Forum post: TODO-forum-link
+* [CICLOPS establishment (cgp-0158)](cgp-0158.md)
+* [CICLOPS Season 2 Funding Request (cgp-0231)](cgp-0231.md)
+* [CICLOPS Season 2 withdrawal completion (cgp-0237)](cgp-0237.md)

--- a/CGPs/cgp-0248.md
+++ b/CGPs/cgp-0248.md
@@ -4,7 +4,7 @@ title: CICLOPS Season 3 Funding Proposal
 date-created: 2026-07-30
 author: '@KishanP'
 status: DRAFT
-discussions-to: TODO-forum-link
+discussions-to: https://forum.celo.org/t/ciclops-season-3-funding-proposal-july-december-2026
 governance-proposal-id:
 date-executed:
 ---

--- a/CGPs/cgp-0248/mainnet.json
+++ b/CGPs/cgp-0248/mainnet.json
@@ -1,0 +1,40 @@
+[
+  {
+    "contract": "Registry",
+    "address": "0x000000000000000000000000000000000000ce10",
+    "function": "setAddressFor",
+    "args": ["EpochManager", "0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972"],
+    "value": "0",
+    "description": "Temporarily set Governance as EpochManager in Registry"
+  },
+  {
+    "contract": "CeloUnreleasedTreasury",
+    "address": "0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f",
+    "function": "release",
+    "args": [
+      "0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972",
+      "35838926000000000000000000"
+    ],
+    "value": "0",
+    "description": "Release 35,838,926 CELO from the unreleased treasury to Governance (Community Fund)"
+  },
+  {
+    "contract": "Registry",
+    "address": "0x000000000000000000000000000000000000ce10",
+    "function": "setAddressFor",
+    "args": ["EpochManager", "0xF424B5e85B290b66aC20f8A9EAB75E25a526725E"],
+    "value": "0",
+    "description": "Restore EpochManager in Registry to original address"
+  },
+  {
+    "contract": "GoldToken",
+    "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+    "function": "increaseAllowance",
+    "args": [
+      "0xd71efa410B6EaAB0bAc3b515B393C886BE70F09E",
+      "35838926000000000000000000"
+    ],
+    "value": "0",
+    "description": "Increase the CICLOPS multisig CELO allowance by 35,838,926"
+  }
+]


### PR DESCRIPTION
## Summary

Adds CGP-0248 — CICLOPS Season 3 Funding Proposal (July–December 2026), authored by @KishanP.

- Releases 35,838,926 CELO ($2,670,000 at the 90-day trailing average price of $0.0745, April 23–July 21, 2026) from the `CeloUnreleasedTreasury` to the Community Fund
- Increases the CICLOPS multisig (`0xd71efa410B6EaAB0bAc3b515B393C886BE70F09E`) CELO allowance by the same amount
- Same 4-transaction pattern as cgp-0246/cgp-0247: temporary `EpochManager` Registry swap → `release` → restore → `increaseAllowance`
- `increaseAllowance` preserves the multisig's remaining Season 2 allowance (~1.76M CELO unspent on-chain)

## Test plan

- [x] Anvil mainnet-fork test executes all 4 transactions as Governance: release event, allowance increase, Registry restoration, and full `transferFrom` withdrawal by the multisig all assert correctly (16/16 checks)
- [x] Treasury balance covers the release (125.6M CELO available)
- [x] Multisig address matches the CICLOPS multisig from cgp-0158/cgp-0231/cgp-0237
- [ ] `discussions-to` forum link pending — will be updated once the forum post is live

🤖 Generated with [Claude Code](https://claude.com/claude-code)