### PR TITLE
Add CGP-250: Celo Governance Guild Season 2 Retro & Funding Top-Up Request

### DIFF
--- a/CGPs/cgp-0250.md
+++ b/CGPs/cgp-0250.md
@@ -1,0 +1,163 @@
+---
+cgp: 250
+title: 'Celo Governance Guild | Season 2 Retro (H1 2026) & Funding Top-Up Request'
+date-created: 2026-08-02
+author: 'Celo Governance Guild (@0xj4an-work, @Wade, @0xGoldo)'
+status: DRAFT
+discussions-to: https://forum.celo.org/t/celo-governance-guild-season-2-funding-request
+governance-proposal-id:
+date-executed:
+---
+
+Proposal Description
+============================
+
+## TL;DR
+
+In H1 2026 we hosted 10 governance calls, merged 54 PRs in the governance repo, and moved 26 CGPs through the process (8 executed on-chain).
+
+Our treasury is fully transparent: every USDm and CELO in and out of the Guild Safe matches the on-chain balance exactly.
+
+The problem: Season 2 was approved as a $60,400 budget, but paid in CELO at ~$0.1135. CELO now trades around $0.069, so the funding is worth about $39,900, a 34% shortfall. We did not overspend a single dollar. The token price dropped.
+
+Status: everything through today is done and paid. 7 of 12 months of guardian payments (Jan to Jul, 34,650 USDm) are executed. The only thing pending is August to December (24,750 in payments plus 465 unspent on the legal line).
+
+The ask: 22,100 USDm. That is the Aug to Dec payments plus the unused legal budget, minus what is still in the Safe (valued at today's price), plus a 10% safety margin, using the same payment method as Prezenti. Anything left over at year-end goes back to the Community Fund.
+
+## Retrospective, H1 2026
+
+**Governance calls.** We hosted 10 calls (#82 on Jan 22 through #91 on Jun 18), each with a public agenda, notes, and recording. Call #92 took place on July 16 (details in the Call Log).
+
+**Repo work.** 54 PRs were merged into celo-org/governance this year. 16 of them came from Guild accounts, keeping CGP statuses current, maintaining the call log, and helping proposals move from draft to vote.
+
+**CGPs.** 26 new CGPs entered the process in 2026. 8 are already executed on-chain, including the whole Season 2 funding round (Communities Guild, cLabs, Stabila, Governance Guild, Celo Foundation, MiniPay, Prezenti, CICLOPS). 3 are in voting, 12 in draft, and 3 were closed (1 rejected, 1 expired, 1 withdrawn).
+
+## KPIs
+
+| Approved KPI | H1 result | Evidence |
+|---|---|---|
+| Calls hosted | 10 (#82 Jan 22 to #91 Jun 18) | Call Log, agenda issues 751, 757, 758, 772, 778, 783, 795, 803, 806, 816 |
+| Calls fully documented | 10 currently | Call Log rows #82 to #90 |
+| Calls documented within 72 hours | Completed | N/A |
+| Average proposer response time | ASAP, adhered to | Governance Proposals category, repo PRs |
+| Proposals requiring procedural rework | None (0 of 26) | Repo PRs |
+| Unique proposers supported | 13 distinct proposer teams across the 26 CGPs merged in 2026 | CGP front-matter author fields, CGPs directory |
+| Average/median call attendance | 13 attendees per call | Call recordings and Gemini meeting notes |
+| Weekly governance communications | Completed | N/A |
+| Governance timelines met | Completed | N/A |
+
+## Payment History (Jan 1 to Jul 20)
+
+Safe: `0xc733285e8e4db433d4cd641f99C46Bf108DCb54F` on Celo, 2-of-3, 38 transactions.
+
+| Season 2 money (2026) | Amount |
+|---|---|
+| Received from Governance (Feb 27 + May 7) | 532,000 CELO |
+| Converted to USDm so far | 460,213 CELO converted to 34,940 USDm (avg $0.076) |
+| Guardian payments Jan to Jul (approved rates) | 34,650 USDm |
+| Left in the Safe today (Jul 20) | 71,787 CELO + 150 USDm, approx $5.1k |
+
+Note: the closing balance includes 395 USDm carried over from Season 1 (55,000 received, 54,000 stipends, 605 expenses in 2025). Of the 1,000 USDm legal and entity expense line, 535 USDm was used on Jul 12 (300 legal entity annual renewal + 235 Google Workspace and domains), leaving 465 USDm available, reserved for future legal costs.
+
+Conversion history:
+
+| Date | How | CELO sold | USDm received | Price |
+|---|---|---|---|---|
+| Feb 28 | Uniswap (multi-pool) | 130,213 | 10,000 | $0.0768 |
+| Mar 20 | Mento | 60,000 | 5,063 | $0.0844 |
+| Apr 20 | Uniswap V4 router | 60,000 | 5,043 | $0.0840 |
+| May 19 | Mento | 60,000 | 4,793 | $0.0799 |
+| Jul 10 | Mento | 150,000 | 10,041 | $0.0669 |
+| **Total** | | **460,213** | **34,940** | **$0.0759 avg** |
+
+## Funding Top-Up Request
+
+### Dilemma: why we are short of the approved budget
+
+Simple version: the approved budget was $60,400. The 532,000 CELO we received is worth about $39,900 in practice (what we already converted plus what is left at today's price). We held the CELO and converted only as payments came due, hoping the price would recover; with the continued decline, that leaves a $20,500 hole, caused entirely by CELO's price, not by our spending.
+
+What is left in the Safe (approx $5.1k) covers roughly one more month. Without new funding, the Safe is empty at the September payment.
+
+### Pending: August to December (the ask)
+
+Everything up to today is executed. What remains for 2026 is five guardian payments (Aug to Dec, 5 x 4,950 = 24,750), plus the 465 USDm still unspent on the approved legal and entity expense line, since legal costs can still come up. We are not asking for that full total. We count what is still in the Safe first, then add a safety margin:
+
+| The math | Amount |
+|---|---|
+| Aug to Dec payments + unused legal line (24,750 + 465) | 25,215 USDm |
+| − Safe holdings today (71,787 CELO at the spot price of $0.0692, + 150 USDm) | −5,117 USDm |
+| = Gap | 20,098 USDm |
+| + 10% safety margin (in case prices move before we convert) | +2,010 USDm |
+| **= Top-up request (rounded)** | **22,100 USDm** |
+
+We follow the same payment method Prezenti used in Season 2. We show both prices: at today's rate ($0.0692) the Safe's CELO is worth about $4,968; at the 90-day average ($0.0749, DefiLlama) it would be about $5,376. We size the request at today's lower rate so the program stays funded even if the market moves, and the remaining 71,787 CELO gets converted right away in weekly batches (about 18,000 each) with every sale price published.
+
+Since the Community Fund holds CELO, the final on-chain request is denominated in CELO: 330,000 CELO, which covers the 22,100 USDm at the executable rate of $0.0692 plus a 3% execution buffer. At the 90-day average of $0.0749 it would be about 295,000 CELO. Same as the original Season 2 request, we will refresh this number to the executable rate at the moment the CGP goes on-chain. Everything converts to USDm on arrival, and anything realized above 22,100 USDm returns to the Community Fund.
+
+Monthly rates stay exactly as approved: 2,200 (Lead) + 1,375 + 1,375 (Guardians). Paid in USDm (not CELO).
+
+### Our commitments
+
+1. Anything left over at year-end goes back to the Community Fund (or counts against Season 4), including the 10% safety margin if it is not needed. Total Season 2 funding stays at or below the approved $60,400.
+2. All CELO gets converted right away, in batches, starting with the 71,787 CELO still in the Safe, converted over four weeks with every sale price published. No more holding tokens and hoping.
+3. We keep publishing the full accounting, and we suggest all future team budgets be paid in USDm so no other team hits this same problem.
+
+Safe (unchanged): `0xc733285e8e4db433d4cd641f99C46Bf108DCb54F`
+
+Proposed Changes
+============================
+
+## Transaction Descriptions
+
+1. Temporarily set Governance as EpochManager in Registry
+   - Destination: Registry (`0x000000000000000000000000000000000000ce10`), function `setAddressFor(string,address)`
+   - Data: identifier = `"EpochManager"`, addr = `0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972` (Governance)
+   - Value: 0 CELO
+
+2. Release 330,000 CELO from the unreleased treasury to Governance (Community Fund)
+   - Destination: CeloUnreleasedTreasury (`0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f`), function `release(address,uint256)`
+   - Data: to = `0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972` (Governance), amount = 330,000 CELO (`330000000000000000000000` in wei)
+   - Value: 0 CELO
+
+3. Restore EpochManager in Registry to the original address
+   - Destination: Registry (`0x000000000000000000000000000000000000ce10`), function `setAddressFor(string,address)`
+   - Data: identifier = `"EpochManager"`, addr = `0xF424B5e85B290b66aC20f8A9EAB75E25a526725E` (original EpochManager)
+   - Value: 0 CELO
+
+4. Increase CELO allowance for the Celo Governance Guild Safe by 330,000
+   - Destination: GoldToken (CELO, `0x471EcE3750Da237f93B8E339c536989b8978a438`), function `increaseAllowance(address,uint256)`
+   - Data: spender = `0xc733285e8e4db433d4cd641f99C46Bf108DCb54F` (Celo Governance Guild Safe), amount = 330,000 CELO (`330000000000000000000000` in wei)
+   - Value: 0 CELO
+
+## Json Script
+
+The full JSON script lives in [`./cgp-0250/mainnet.json`](./cgp-0250/mainnet.json).
+
+Verification
+============================
+
+- Contract addresses on Celoscan:
+  - Registry: <https://celoscan.io/address/0x000000000000000000000000000000000000ce10>
+  - CeloUnreleasedTreasury: <https://celoscan.io/address/0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f>
+  - GoldToken (CELO): <https://celoscan.io/address/0x471EcE3750Da237f93B8E339c536989b8978a438>
+  - EpochManager (Governance, used in the temporary swap): <https://celoscan.io/address/0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972>
+  - EpochManager (original, restored at the end): <https://celoscan.io/address/0xF424B5e85B290b66aC20f8A9EAB75E25a526725E>
+  - Celo Governance Guild Safe: <https://celoscan.io/address/0xc733285e8e4db433d4cd641f99C46Bf108DCb54F>
+- Amount encoding: 330,000 CELO = 330,000 x 10^18 = `330000000000000000000000` (CELO has 18 decimals).
+- Effect: after execution, 330,000 CELO is released from the unreleased treasury into Governance (Community Fund), and the Guild Safe can pull up to 330,000 CELO from Governance via `transferFrom`, following the same 4-step pattern used in CGP-246, CGP-247 and CGP-248.
+- Every payment and conversion referenced in this proposal can be reproduced from on-chain history of the Safe and from the CGP files in this repo.
+
+Risks
+============================
+
+- **Market risk.** If USDm depegs materially, the effective value of the top-up shifts. Mitigated by paying stipends promptly after each conversion and by the 10% safety margin.
+- **Operational risk.** The 2-of-3 Safe threshold and the published conversion schedule reduce single-signer risk and remove discretion on when to convert.
+- **Governance precedent.** The on-chain request is denominated in CELO because the Community Fund holds CELO, matching the pattern used in CGP-246, CGP-247 and CGP-248. To honour the operational commitment to remove CELO price exposure, the Guild converts the 330,000 CELO to USDm immediately on arrival, in weekly batches with every sale price published (see commitment 2 above). Future team budgets should be requested in USDm at the source so no other team hits the same shortfall.
+- No protocol, consensus, PoS, or protocol-economics changes are introduced by this proposal.
+
+Useful Links
+============================
+
+- Season 2 request: [CGP-223](./cgp-0223.md), [forum thread](https://forum.celo.org/t/celo-governance-guild-season-2-funding-request)
+- Call Log: [`Call_Log.md`](../Call_Log.md)
+- Safe history: <https://celoscan.io/address/0xc733285e8e4db433d4cd641f99C46Bf108DCb54F>

--- a/CGPs/cgp-0250.md
+++ b/CGPs/cgp-0250.md
@@ -109,8 +109,8 @@ Proposed Changes
 
 ## Transaction Descriptions
 
-1. Increase CELO allowance for the Celo Governance Guild Safe by 330,000
-   - Destination: GoldToken (CELO, `0x471EcE3750Da237f93B8E339c536989b8978a438`), function `increaseAllowance(address,uint256)`
+1. Approve 330,000 CELO allowance for the Celo Governance Guild Safe
+   - Destination: GoldToken (CELO, `0x471EcE3750Da237f93B8E339c536989b8978a438`), function `approve(address,uint256)`
    - Data: spender = `0xc733285e8e4db433d4cd641f99C46Bf108DCb54F` (Celo Governance Guild Safe)
    - Amount = 330,000 CELO (`330000000000000000000000` in wei)
    - Value: 0 CELO

--- a/CGPs/cgp-0250.md
+++ b/CGPs/cgp-0250.md
@@ -109,25 +109,12 @@ Proposed Changes
 
 ## Transaction Descriptions
 
-1. Temporarily set Governance as EpochManager in Registry
-   - Destination: Registry (`0x000000000000000000000000000000000000ce10`), function `setAddressFor(string,address)`
-   - Data: identifier = `"EpochManager"`, addr = `0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972` (Governance)
-   - Value: 0 CELO
-
-2. Release 330,000 CELO from the unreleased treasury to Governance (Community Fund)
-   - Destination: CeloUnreleasedTreasury (`0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f`), function `release(address,uint256)`
-   - Data: to = `0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972` (Governance), amount = 330,000 CELO (`330000000000000000000000` in wei)
-   - Value: 0 CELO
-
-3. Restore EpochManager in Registry to the original address
-   - Destination: Registry (`0x000000000000000000000000000000000000ce10`), function `setAddressFor(string,address)`
-   - Data: identifier = `"EpochManager"`, addr = `0xF424B5e85B290b66aC20f8A9EAB75E25a526725E` (original EpochManager)
-   - Value: 0 CELO
-
-4. Increase CELO allowance for the Celo Governance Guild Safe by 330,000
+1. Increase CELO allowance for the Celo Governance Guild Safe by 330,000
    - Destination: GoldToken (CELO, `0x471EcE3750Da237f93B8E339c536989b8978a438`), function `increaseAllowance(address,uint256)`
-   - Data: spender = `0xc733285e8e4db433d4cd641f99C46Bf108DCb54F` (Celo Governance Guild Safe), amount = 330,000 CELO (`330000000000000000000000` in wei)
+   - Data: spender = `0xc733285e8e4db433d4cd641f99C46Bf108DCb54F` (Celo Governance Guild Safe)
+   - Amount = 330,000 CELO (`330000000000000000000000` in wei)
    - Value: 0 CELO
+
 
 ## Json Script
 
@@ -137,14 +124,10 @@ Verification
 ============================
 
 - Contract addresses on Celoscan:
-  - Registry: <https://celoscan.io/address/0x000000000000000000000000000000000000ce10>
-  - CeloUnreleasedTreasury: <https://celoscan.io/address/0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f>
   - GoldToken (CELO): <https://celoscan.io/address/0x471EcE3750Da237f93B8E339c536989b8978a438>
-  - EpochManager (Governance, used in the temporary swap): <https://celoscan.io/address/0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972>
-  - EpochManager (original, restored at the end): <https://celoscan.io/address/0xF424B5e85B290b66aC20f8A9EAB75E25a526725E>
   - Celo Governance Guild Safe: <https://celoscan.io/address/0xc733285e8e4db433d4cd641f99C46Bf108DCb54F>
 - Amount encoding: 330,000 CELO = 330,000 x 10^18 = `330000000000000000000000` (CELO has 18 decimals).
-- Effect: after execution, 330,000 CELO is released from the unreleased treasury into Governance (Community Fund), and the Guild Safe can pull up to 330,000 CELO from Governance via `transferFrom`, following the same 4-step pattern used in CGP-246, CGP-247 and CGP-248.
+- Effect: after execution, the Guild Safe can pull up to 330,000 CELO from the Governance contract via `transferFrom`, following the same direct-allowance pattern used in CGP-223 (Season 2 original).
 - Every payment and conversion referenced in this proposal can be reproduced from on-chain history of the Safe and from the CGP files in this repo.
 
 Risks
@@ -152,7 +135,7 @@ Risks
 
 - **Market risk.** If USDm depegs materially, the effective value of the top-up shifts. Mitigated by paying stipends promptly after each conversion and by the 10% safety margin.
 - **Operational risk.** The 2-of-3 Safe threshold and the published conversion schedule reduce single-signer risk and remove discretion on when to convert.
-- **Governance precedent.** The on-chain request is denominated in CELO because the Community Fund holds CELO, matching the pattern used in CGP-246, CGP-247 and CGP-248. To honour the operational commitment to remove CELO price exposure, the Guild converts the 330,000 CELO to USDm immediately on arrival, in weekly batches with every sale price published (see commitment 2 above). Future team budgets should be requested in USDm at the source so no other team hits the same shortfall.
+- **Governance precedent.** The on-chain request is denominated in CELO because the Community Fund holds CELO, matching the direct-allowance pattern used in CGP-223 (Season 2 original). To honour the operational commitment to remove CELO price exposure, the Guild converts the 330,000 CELO to USDm immediately on arrival, in weekly batches with every sale price published (see commitment 2 above). Future team budgets should be requested in USDm at the source so no other team hits the same shortfall.
 - No protocol, consensus, PoS, or protocol-economics changes are introduced by this proposal.
 
 Useful Links

--- a/CGPs/cgp-0250/mainnet.json
+++ b/CGPs/cgp-0250/mainnet.json
@@ -1,0 +1,40 @@
+[
+  {
+    "contract": "Registry",
+    "address": "0x000000000000000000000000000000000000ce10",
+    "function": "setAddressFor",
+    "args": ["EpochManager", "0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972"],
+    "value": "0",
+    "description": "Temporarily set Governance as EpochManager in Registry"
+  },
+  {
+    "contract": "CeloUnreleasedTreasury",
+    "address": "0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f",
+    "function": "release",
+    "args": [
+      "0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972",
+      "330000000000000000000000"
+    ],
+    "value": "0",
+    "description": "Release 330,000 CELO from the unreleased treasury to Governance (Community Fund)"
+  },
+  {
+    "contract": "Registry",
+    "address": "0x000000000000000000000000000000000000ce10",
+    "function": "setAddressFor",
+    "args": ["EpochManager", "0xF424B5e85B290b66aC20f8A9EAB75E25a526725E"],
+    "value": "0",
+    "description": "Restore EpochManager in Registry to original address"
+  },
+  {
+    "contract": "GoldToken",
+    "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
+    "function": "increaseAllowance",
+    "args": [
+      "0xc733285e8e4db433d4cd641f99C46Bf108DCb54F",
+      "330000000000000000000000"
+    ],
+    "value": "0",
+    "description": "Increase the Celo Governance Guild Safe CELO allowance by 330,000"
+  }
+]

--- a/CGPs/cgp-0250/mainnet.json
+++ b/CGPs/cgp-0250/mainnet.json
@@ -2,7 +2,7 @@
   {
     "contract": "GoldToken",
     "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
-    "function": "increaseAllowance",
+    "function": "approve",
     "args": [
       "0xc733285e8e4db433d4cd641f99C46Bf108DCb54F",
       "330000000000000000000000"

--- a/CGPs/cgp-0250/mainnet.json
+++ b/CGPs/cgp-0250/mainnet.json
@@ -1,32 +1,5 @@
 [
   {
-    "contract": "Registry",
-    "address": "0x000000000000000000000000000000000000ce10",
-    "function": "setAddressFor",
-    "args": ["EpochManager", "0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972"],
-    "value": "0",
-    "description": "Temporarily set Governance as EpochManager in Registry"
-  },
-  {
-    "contract": "CeloUnreleasedTreasury",
-    "address": "0x7A8c7a833565fc428cdFBa20FE03fAfb178A434f",
-    "function": "release",
-    "args": [
-      "0xD533Ca259b330c7A88f74E000a3FaEa2d63B7972",
-      "330000000000000000000000"
-    ],
-    "value": "0",
-    "description": "Release 330,000 CELO from the unreleased treasury to Governance (Community Fund)"
-  },
-  {
-    "contract": "Registry",
-    "address": "0x000000000000000000000000000000000000ce10",
-    "function": "setAddressFor",
-    "args": ["EpochManager", "0xF424B5e85B290b66aC20f8A9EAB75E25a526725E"],
-    "value": "0",
-    "description": "Restore EpochManager in Registry to original address"
-  },
-  {
     "contract": "GoldToken",
     "address": "0x471EcE3750Da237f93B8E339c536989b8978a438",
     "function": "increaseAllowance",
@@ -34,7 +7,8 @@
       "0xc733285e8e4db433d4cd641f99C46Bf108DCb54F",
       "330000000000000000000000"
     ],
-    "value": "0",
-    "description": "Increase the Celo Governance Guild Safe CELO allowance by 330,000"
+    "value": "0"
   }
 ]
+
+


### PR DESCRIPTION
## Summary

Season 2 retrospective (H1 2026) and funding top-up request for the Celo Governance Guild.

- H1 delivered: 10 governance calls (#82 to #91), 54 PRs merged, 26 CGPs moved through the process (8 executed on-chain).
- Ask: 22,100 USDm to fund the remaining Aug to Dec 2026 guardian payments plus the unused legal line, net of Safe holdings, plus a 10% safety margin. On-chain request denominated in CELO (330,000 CELO) because the Community Fund holds CELO; converted to USDm on arrival per commitment in the proposal.
- Transaction pattern identical to CGP-246 / CGP-247 / CGP-248 (temp EpochManager swap, release from CeloUnreleasedTreasury, restore, increaseAllowance to Guild Safe).

## Files

- `CGPs/cgp-0250.md`
- `CGPs/cgp-0250/mainnet.json`